### PR TITLE
fix(ci): match Linux AppImage upload path to renamed filename

### DIFF
--- a/.github/workflows/build_orca.yml
+++ b/.github/workflows/build_orca.yml
@@ -437,8 +437,10 @@ jobs:
         if: ${{ ! env.ACT && runner.os == 'Linux' }}
         uses: actions/upload-artifact@v7
         with:
-          name: OrcaSlicer_Linux_ubuntu_${{ env.ubuntu-ver }}_${{ env.ver }}
-          path: './build/OrcaSlicer_Linux_AppImage${{ env.ubuntu-ver-str }}_${{ env.ver }}.AppImage'
+          name: OrcaSlicerWaveOverhangs_Linux_ubuntu_${{ env.ubuntu-ver }}_${{ env.ver }}
+          # The rename step above produces OrcaSlicerWaveOverhangs_..., so the
+          # upload path needs to match or nothing gets uploaded to the release.
+          path: './build/OrcaSlicerWaveOverhangs_Linux_AppImage${{ env.ubuntu-ver-str }}_${{ env.ver }}.AppImage'
 
       - name: Upload OrcaSlicer_profile_validator Ubuntu
         if: ${{ ! env.ACT && runner.os == 'Linux' && !vars.SELF_HOSTED }}


### PR DESCRIPTION
The rename step renames the AppImage to `OrcaSlicerWaveOverhangs_Linux_AppImage…`, but the upload-artifact step was still reading the old `OrcaSlicer_Linux_AppImage…` path. As a result, no Linux AppImage was attached to v0.1.0 or v0.1.1 releases.