### PR TITLE
fix(kaiser): align LaSO overlap + anchor defaults with Python reference

### DIFF
--- a/src/libslic3r/PrintConfig.cpp
+++ b/src/libslic3r/PrintConfig.cpp
@@ -4803,11 +4803,12 @@ void PrintConfigDef::init_fff_params()
     def->label = L("Kaiser LaSO overlap");
     def->category = L("Strength");
     def->tooltip = L("Overlap fraction between successive Kaiser LaSO offset rings. "
-                     "Higher values produce denser, more solid wave fills.");
+                     "Higher values produce denser, more solid wave fills. "
+                     "Default 0.125 matches Kaiser's Python reference.");
     def->mode = comAdvanced;
     def->min = 0.0;
     def->max = 0.9;
-    def->set_default_value(new ConfigOptionFloat(0.15));
+    def->set_default_value(new ConfigOptionFloat(0.125));
 
     def = this->add("wave_overhang_min_angle", coFloat);
     def->label = L("Wave overhang min angle");
@@ -4899,11 +4900,12 @@ void PrintConfigDef::init_fff_params()
     def->category = L("Strength");
     def->tooltip = L("Number of additional rings emitted starting from the supported edge, before the "
                      "main wave fan. More passes give stronger anchoring at the cost of extra "
-                     "plastic/time. 0 disables; 1 is default; 2-5 for extreme overhangs.");
+                     "plastic/time. 0 is default (matches Kaiser's Python reference); 1-5 for extra "
+                     "anchoring on extreme overhangs.");
     def->mode = comAdvanced;
     def->min = 0;
     def->max = 5;
-    def->set_default_value(new ConfigOptionInt(1));
+    def->set_default_value(new ConfigOptionInt(0));
 
     def = this->add("wave_overhang_direction_bias", coFloat);
     def->label = L("Wave overhang direction bias (Experimental)");


### PR DESCRIPTION
## Summary

Our Kaiser LaSO defaults drifted from Kaiser's Python reference script. This PR resets two of them:

- `wave_overhang_laso_overlap`: **0.15 → 0.125** (Kaiser's reference uses 0.125)
- `wave_overhang_anchor_passes`: **1 → 0** (Kaiser's reference emits no anchor ring before the main fan)

Together the drift adds ~20% overlap and one extra root-edge ring, which on some geometries over-extrudes and fights the actual cantilever-support rings. Triggered by a user test print where 2/3 symmetric overhang arms succeeded but the third failed completely.

## Not changed here

`wave_overhang_flow_ratio` (2.0) vs Kaiser's ~1.5 is also a divergence but the setting is shared with the Andersons algorithm, which is calibrated at 2.0. Tuning it affects both algorithms and deserves its own PR.

## Test plan

- [ ] Build and slice the same test model that failed previously; compare ring spacing + flow in preview
- [ ] Verify no regression on known-good Andersons prints (flow_ratio unchanged)
- [ ] After merge, append a new version entry in waveoverhangs.com waveDefaults.ts at release time