### PR TITLE
docs: refresh README for current state of project

### DIFF
--- a/README.md
+++ b/README.md
@@ -12,7 +12,7 @@ Fork of OrcaSlicer with wave‑pattern overhang printing, two pluggable algorith
 <br>
 
 [![Download](https://img.shields.io/github/v/release/dennisklappe/OrcaSlicer-WaveOverhangs?include_prereleases&label=Download&color=brightgreen&style=for-the-badge)](https://github.com/dennisklappe/OrcaSlicer-WaveOverhangs/releases)
-[![Build](https://img.shields.io/github/actions/workflow/status/dennisklappe/OrcaSlicer-WaveOverhangs/build_all.yml?branch=wave-overhangs&label=Build&style=for-the-badge)](https://github.com/dennisklappe/OrcaSlicer-WaveOverhangs/actions/workflows/build_all.yml)
+[![Build](https://img.shields.io/github/actions/workflow/status/dennisklappe/OrcaSlicer-WaveOverhangs/build_all.yml?branch=main&label=Build&style=for-the-badge)](https://github.com/dennisklappe/OrcaSlicer-WaveOverhangs/actions/workflows/build_all.yml)
 [![Stars](https://img.shields.io/github/stars/dennisklappe/OrcaSlicer-WaveOverhangs?style=for-the-badge)](https://github.com/dennisklappe/OrcaSlicer-WaveOverhangs/stargazers)
 [![License](https://img.shields.io/badge/license-AGPL--3.0-blue?style=for-the-badge)](https://github.com/OrcaSlicer/OrcaSlicer/blob/main/LICENSE.txt)
 
@@ -37,12 +37,14 @@ This fork ports the technique into OrcaSlicer and exposes two pluggable generato
 ## Main features
 
 - **Two wave‑overhang algorithms** with an in‑GUI dropdown
-  - **Andersons**: port of [stmcculloch/PrusaSlicer‑WaveOverhangs](https://github.com/stmcculloch/PrusaSlicer-WaveOverhangs). Arc‑overhang descendant with narrow‑region splitting and smart/zig‑zag/monotonic pattern selection.
-  - **Kaiser LaSO**: C++ reimplementation of [Rieks Kaiser's MSc thesis script](https://github.com/riekskaiser/wave_LaSO). Auto seed‑curve detection, multi‑overhang handling, pipeline‑integrated (no G‑code post‑processing).
-- **Dedicated Wave overhangs tab** in Print Settings with grouped sections: General, Geometry, Anchoring, Andersons, Kaiser LaSO, Speed, Cooling, Floor layers, Debug.
-- **30+ expert tunables** for experimentation: line spacing, anchor bite, seam mode, spacing mode, direction bias, perimeter overlap, narrow‑split threshold, wavefront advance, discretization, arc resolution, max iterations, authoritative floor layers, and more.
+  - **Andersons**: port of [stmcculloch/PrusaSlicer‑WaveOverhangs](https://github.com/stmcculloch/PrusaSlicer-WaveOverhangs). Arc‑overhang descendant with narrow‑region splitting and Smart/ZigZag/Monotonic pattern selection.
+  - **Kaiser LaSO**: C++ reimplementation of [Rieks Kaiser's MSc thesis script](https://github.com/riekskaiser/wave_LaSO). Auto seed‑curve detection, multi‑overhang handling, pipeline‑integrated (no G‑code post‑processing). Still experimental, not producing reliable prints yet.
+- **Dedicated Wave overhangs tab** in Print Settings with grouped sections: General, Geometry, Algorithm tuning (algorithm‑specific rows appear per selected algorithm), Speed, Cooling, Floor layers, Support integration, Debug.
+- **~20 expert tunables** for experimentation: line spacing, line width, flow ratio, ring overlap, seam mode, spacing mode, pattern, perimeter overlap, minimum wave width, max iterations, authoritative floor layers, cooling overrides, and more.
+- **Community test‑print database** at **[waveoverhangs.com](https://waveoverhangs.com)** where you can upload your results with settings and compare prints side‑by‑side.
 - **Wave‑aware support integration**: supports only generate for overhang areas the wave couldn't cover.
 - **G‑code debug markers**: `;WAVE_OVERHANG_CONFIG …` header block and per‑region `;WAVE_OVERHANG_START/END` tags for easy post‑process verification.
+- **First‑launch config importer**: auto‑copies existing configs from OrcaSlicer, Bambu Studio, or PrusaSlicer so users don't start from zero.
 - **100% opt‑in**: master toggle off means identical behavior to upstream OrcaSlicer.
 
 ---
@@ -62,7 +64,7 @@ Prebuilt binaries for tagged releases on the **[Releases page](https://github.co
 5. Slice and inspect the G‑code preview. Wave extrusions appear over detected overhang regions.
 
 > **Simple mode** shows just the master toggle plus the algorithm dropdown.
-> Switch to **Advanced** (top‑right mode selector) to tune individual parameters like line spacing, anchor bite, Kaiser LaSO overlap, etc.
+> Switch to **Advanced** (top‑right mode selector) to tune individual parameters like line spacing, flow ratio, ring overlap, seam mode, etc.
 
 For the full reference of every config option with tuning hints, see **[docs/WAVE_OVERHANG_SETTINGS.md](docs/WAVE_OVERHANG_SETTINGS.md)**.
 
@@ -74,12 +76,12 @@ For the full reference of every config option with tuning hints, see **[docs/WAV
 
 |  | Andersons (arc‑overhang derived) | Kaiser LaSO |
 |---|---|---|
-| **Geometric primitive** | Concentric arcs grown from interior seed points, clipped to the overhang boundary | Lateral offsets of a root‑edge seed curve, buffered by `line_width × (1 − overlap)` each ring |
-| **Seed** | Interior points where medial‑axis fronts propagate | Curve anchored to the supported edge (auto‑detected in our port as overhang‑boundary ∩ lower‑slice‑boundary) |
-| **Propagation** | Radial: arcs fan out | Boustrophedon: parallel rings alternate direction |
-| **Research origin** | Wave‑overhang research by Janis A. Andersons (PhD candidate, University of Twente). Arc‑overhang predecessor and PrusaSlicer port by Steven McCulloch (see Credits) | Kaiser's MSc thesis, University of Twente |
+| **Geometric primitive** | Wavefront propagation outward from the supported edge, offset by `wave_spacing` each iteration, clipped to the overhang region | Lateral offsets of a root‑edge seed curve, stepped outward by `line_width × (1 − ring_overlap)` each ring |
+| **Seed** | Outer wall / supported‑edge boundary, dilated into the overhang region | Curve anchored to the supported edge (auto‑detected in our port as overhang‑boundary ∩ lower‑slice‑boundary) |
+| **Propagation** | Outward wavefronts clipped to current‑layer boundary, with Smart / Monotonic / ZigZag pattern selection for within‑ring traversal | Iterative concentric offsets from the seed, each ring clipped to the current‑layer boundary |
+| **Research origin** | Wave‑overhang research by Janis A. Andersons (University of Twente). Arc‑overhang predecessor and PrusaSlicer port by Steven McCulloch (see Credits) | Rieks Kaiser's MSc thesis under Andersons' supervision, University of Twente |
 
-Both algorithms have strengths and weaknesses depending on overhang geometry. Try both on your model and compare.
+Both algorithms have strengths and weaknesses depending on overhang geometry. Try both on your model and compare. Kaiser LaSO is still experimental in our port and not yet producing reliable prints; Andersons is the recommended default.
 
 ---
 
@@ -103,11 +105,12 @@ make -j$(nproc)
 
 ## Current limitations
 
-- **Experimental.** The tunable space is large (30+ knobs across two algorithms) and most parameter combinations have not been print‑tested yet. Expect rough edges. Please share what works and what doesn't.
+- **Experimental.** The tunable space is large (~20 knobs across two algorithms) and most parameter combinations have not been print‑tested yet. Expect rough edges. Please share what works and what doesn't at **[waveoverhangs.com](https://waveoverhangs.com)**.
+- **Kaiser LaSO still unreliable.** The Kaiser algorithm is in the slicer as a second option but not yet producing consistently good prints. Stick with Andersons for now unless you're helping debug Kaiser.
 - **PLA recommended.** Wave overhangs need each ring to cool and become rigid before the next pass anchors to it. PLA with max part‑cooling works well. PETG, ABS and PC are likely to fail (PETG cools too slowly and delaminates under heavy fan).
 - **Warping on larger spans.** Laterally supported overhangs are prone to warping driven by thermal gradients, reheating of earlier layers, and nozzle pressure. Smaller overhangs print cleanly; larger spans may still need traditional supports. See **[docs/LIMITATIONS.md](docs/LIMITATIONS.md)** for the mechanisms and mitigations.
 - **Kaiser pin supports are not ported.** Kaiser's original places discrete pin‑support nubs under overhangs. Not planned, since the goal here is fully support‑free overhangs. Use `support_remaining_areas_after_wave_overhangs` with Orca's normal supports if wave can't cover everything.
-- **Not yet real‑print tested on Windows/macOS.** CI produces builds for all platforms, but testing has focused on Linux so far.
+- **Platform testing status:** real‑print tested on Linux and Windows. macOS builds pass CI but haven't been validated against a physical printer yet.
 
 ---
 


### PR DESCRIPTION
Bring the README back in sync with the code after recent cleanup passes. No code changes.

Highlights:
- Algorithm comparison table rewritten. Was inaccurate on both sides (Andersons doesn't use medial-axis seeds, Kaiser's propagation isn't Boustrophedon, neither produces literal concentric arcs).
- Tunables list trimmed to only what still exists after PR #13 and #14.
- Platform testing status updated (Linux + Windows confirmed, macOS TBD).
- waveoverhangs.com called out as a top-level feature.
- Kaiser honestly labeled as still experimental.
- Various small stale references fixed.