### PR TITLE
refactor(wave-overhangs): remove line_width knob, auto-use nozzle diameter

### DIFF
--- a/docs/WAVE_OVERHANG_SETTINGS.md
+++ b/docs/WAVE_OVERHANG_SETTINGS.md
@@ -127,16 +127,9 @@ Center-to-center distance between adjacent wave extrusions.
 - **Type:** float (mm) · **Default:** `0.35` · **Min:** `0.01`
 - **Tuning:** tighter (0.28–0.30) = denser fill, stronger, slower, risk of over-extrusion on cantilevers. Wider (0.40–0.50) = faster, visible gaps between rings, weaker.
 
-#### `wave_overhang_line_width`
-
-Extrusion width for wave lines. Base extrusion volume is `width × layer_height`; the per-mm volume can then be scaled by `wave_overhang_flow_ratio`.
-
-- **Type:** float (mm) · **Default:** `0.4` · **Min:** `0.1`
-- **Tuning:** typically match or slightly undercut the nozzle diameter. Narrower lines (0.35–0.38) cool faster and hold shape better on unsupported tips; wider lines are stronger but sag more.
-
 #### `wave_overhang_flow_ratio`
 
-Multiplier applied to the base extrusion flow for wave-overhang lines. Base cross-section is `wave line width × layer height`; the final per-mm volume is `base × flow_ratio`.
+Multiplier applied to the base extrusion flow for wave-overhang lines. Base cross-section is `nozzle_diameter × layer_height`; the final per-mm volume is `base × flow_ratio`.
 
 - **Type:** float (multiplier) · **Default:** `2.0` · **Range:** `0.1 – 3.0`
 - **Why 2.0:** Wave-overhang lines hang in air, not squished against a layer below, so the `width × layer-height` shape does not apply. Empirically they need roughly 2× the base flow to stay continuous — this matches Andersons' reference value of `~0.15 mm²` for a 0.4 mm nozzle.

--- a/src/libslic3r/GCode.cpp
+++ b/src/libslic3r/GCode.cpp
@@ -2549,7 +2549,7 @@ void GCode::_do_export(Print& print, GCodeOutputStream &file, ThumbnailsGenerato
                     }
                     file.write_format(
                         "; WAVE_OVERHANG_CONFIG region=%zu algo=%s outer_perim=%d"
-                        " spacing=%.3f width=%.3f flow_ratio=%.3f speed=%.1f travel=%.1f fan=%d"
+                        " spacing=%.3f flow_ratio=%.3f speed=%.1f travel=%.1f fan=%d"
                         " floor_layers=%d min_angle=%.1f min_length=%.2f max_iterations=%d"
                         " ring_overlap=%.2f"
                         " pattern=%s spacing_mode=%s seam_mode=%s"
@@ -2562,7 +2562,6 @@ void GCode::_do_export(Print& print, GCodeOutputStream &file, ThumbnailsGenerato
                         region_idx, algo,
                         rc.wave_overhang_outer_perimeters.value,
                         rc.wave_overhang_line_spacing.value,
-                        rc.wave_overhang_line_width.value,
                         rc.wave_overhang_flow_ratio.value,
                         rc.wave_overhang_print_speed.value,
                         rc.wave_overhang_travel_speed.value,

--- a/src/libslic3r/PerimeterGenerator.cpp
+++ b/src/libslic3r/PerimeterGenerator.cpp
@@ -1103,7 +1103,7 @@ static std::tuple<std::vector<ExtrusionPaths>, Polygons> generate_wave_overhang_
     params.perimeter_count        = perimeter_count;
     params.additional_shell_count = additional_shell_count;
     params.line_spacing           = region_config.wave_overhang_line_spacing.value;
-    params.line_width             = region_config.wave_overhang_line_width.value;
+    params.line_width             = overhang_flow.nozzle_diameter();  // Always match nozzle; line_width != nozzle has no sensible regime in air.
     params.overhang_flow          = overhang_flow;
     params.scaled_resolution      = scaled_resolution;
     params.spacing_mode           = (region_config.wave_overhang_spacing_mode == wosmProgressive)

--- a/src/libslic3r/Preset.cpp
+++ b/src/libslic3r/Preset.cpp
@@ -894,7 +894,7 @@ static std::vector<std::string> s_Preset_print_options {
     "wave_overhangs", "wave_overhangs_instead_of_bridges", "wave_overhang_outer_perimeters",
     "wave_overhang_perimeter_overlap", "wave_overhang_minimum_width", "wave_overhang_pattern",
     "support_remaining_areas_after_wave_overhangs",
-    "wave_overhang_line_spacing", "wave_overhang_line_width", "wave_overhang_flow_ratio",
+    "wave_overhang_line_spacing", "wave_overhang_flow_ratio",
     "wave_overhang_print_speed", "wave_overhang_travel_speed", "wave_overhang_fan_speed",
     "wave_overhang_nozzle_temp", "wave_overhang_min_wave_time", "wave_overhang_min_layer_time",
     "wave_overhang_floor_layers",

--- a/src/libslic3r/PrintConfig.cpp
+++ b/src/libslic3r/PrintConfig.cpp
@@ -4674,16 +4674,6 @@ void PrintConfigDef::init_fff_params()
     def->min = 0.01;
     def->set_default_value(new ConfigOptionFloat(0.35));
 
-    def = this->add("wave_overhang_line_width", coFloat);
-    def->label = L("Line width");
-    def->category = L("Strength");
-    def->tooltip = L("Extrusion width used for wave-overhang lines. Typically a bit narrower "
-                     "than the nozzle diameter.");
-    def->sidetext = L("mm");
-    def->mode = comAdvanced;
-    def->min = 0.1;
-    def->set_default_value(new ConfigOptionFloat(0.4));
-
     def = this->add("wave_overhang_flow_ratio", coFloat);
     def->label = L("Flow ratio");
     def->category = L("Strength");

--- a/src/libslic3r/PrintConfig.hpp
+++ b/src/libslic3r/PrintConfig.hpp
@@ -1151,7 +1151,6 @@ PRINT_CONFIG_CLASS_DEFINE(
     ((ConfigOptionFloat,                wave_overhang_minimum_width))
     ((ConfigOptionEnum<WaveOverhangPattern>, wave_overhang_pattern))
     ((ConfigOptionFloat,                wave_overhang_line_spacing))
-    ((ConfigOptionFloat,                wave_overhang_line_width))
     ((ConfigOptionFloat,                wave_overhang_flow_ratio))
     ((ConfigOptionFloat,                wave_overhang_print_speed))
     ((ConfigOptionFloat,                wave_overhang_travel_speed))

--- a/src/slic3r/GUI/ConfigManipulation.cpp
+++ b/src/slic3r/GUI/ConfigManipulation.cpp
@@ -979,7 +979,6 @@ void ConfigManipulation::toggle_print_fff_options(DynamicPrintConfig *config, co
         std::string("wave_overhangs_instead_of_bridges"),
         std::string("wave_overhang_algorithm"),
         std::string("wave_overhang_outer_perimeters"),
-        std::string("wave_overhang_line_width"),
         std::string("wave_overhang_print_speed"),
         std::string("wave_overhang_travel_speed"),
         std::string("wave_overhang_fan_speed"),

--- a/src/slic3r/GUI/Tab.cpp
+++ b/src/slic3r/GUI/Tab.cpp
@@ -2415,7 +2415,6 @@ void TabPrint::build()
 
         optgroup = page->new_optgroup(L("Geometry"), L"param_overhang");
         optgroup->append_single_option_line("wave_overhang_outer_perimeters");
-        optgroup->append_single_option_line("wave_overhang_line_width");
         optgroup->append_single_option_line("wave_overhang_seam_mode");
 
         // Algorithm tuning: rows here are filtered by the active algorithm


### PR DESCRIPTION
For wave overhangs there's no physical regime where \`line_width ≠ nozzle_diameter\` is helpful:

- **Kaiser** uses fixed \`nozzle²\` flow and derives ring spacing as \`line_width × (1 − ring_overlap)\`. Shrinking line_width below nozzle shrinks spacing without reducing flow → rings over-extrude and clash. Above nozzle leaves under-packed gaps.
- **Andersons** uses flow = \`line_width × layer_height × flow_ratio\` and treats line_spacing separately. Mismatched line_width just distorts the flow/spacing relationship.

On air there's nothing to squish the extrudate flat against, so the printed line width is mostly determined by nozzle bore + flow rate regardless of what the slicer records. Exposing the knob as a user control just invites users to tune a parameter whose only sensible value is already the nozzle diameter.

## Changes

Removed:
- \`wave_overhang_line_width\` config def + hpp macro + preset list entry
- Tab.cpp UI row
- ConfigManipulation.cpp toggle entry
- GCode.cpp debug header field
- \`docs/WAVE_OVERHANG_SETTINGS.md\` section

Internal: PerimeterGenerator binding now sets \`params.line_width = overhang_flow.nozzle_diameter()\`. The CommonParams field stays (generators read it identically); no generator changes needed.

8 files touched, −21 lines net.