### PR TITLE
docs: dark-mode SVG + repo-wide em/en-dash cleanup

### DIFF
--- a/docs/ALGORITHMS.md
+++ b/docs/ALGORITHMS.md
@@ -23,12 +23,10 @@ The real differences between the two are **what the seed looks like** and **what
 |---|---|---|
 | **Seed** | Narrow band along the support-overhang boundary | Full lower-slice polygon shrunk inward by 2 × nozzle (treated as a closed curve) |
 | **What each iteration offsets** | The accumulated filled region | The previous ring (a curve) |
-| **What an iteration emits** | A polyline sampled along the new outline — a wavefront | A closed ring around the previous ring |
+| **What an iteration emits** | A polyline sampled along the new outline (a wavefront) | A closed ring around the previous ring |
 | **How rings connect** | Pattern mode: Smart / Monotonic / ZigZag | Strict lateral offset of the previous ring |
 | **Loop terminates when** | New area growth falls below a threshold (saturation) | The outward offset can't grow further inside the current-layer boundary |
 | **Flow model** | `flow_ratio × standard flow` (layer-height-dependent) | Fixed `nozzle²` mm³/mm (layer-height-independent) |
-
-Neither algorithm grows "inward from the outer wall" — the outer wall of an overhang would have to be printed on air, which is the problem these algorithms exist to solve. Both grow *outward from the support*.
 
 ## Andersons
 
@@ -66,12 +64,12 @@ flowchart TD
 
 ### Key parameters
 
-- `wave_overhang_line_spacing` — distance between successive wavefronts
-- `wave_overhang_flow_ratio` — multiplier on standard flow per wave extrusion (layer-height-dependent by nature)
-- `wave_overhang_pattern` — Smart / Monotonic / ZigZag, affects how rings are traversed after all are generated
-- `wave_overhang_perimeter_overlap` — how far waves extend toward the outer wall
-- `wave_overhang_minimum_width` — split waves at narrow necks narrower than this
-- `wave_overhang_min_new_area` — saturation threshold
+- `wave_overhang_line_spacing`: distance between successive wavefronts
+- `wave_overhang_flow_ratio`: multiplier on standard flow per wave extrusion (layer-height-dependent by nature)
+- `wave_overhang_pattern`: Smart / Monotonic / ZigZag, affects how rings are traversed after all are generated
+- `wave_overhang_perimeter_overlap`: how far waves extend toward the outer wall
+- `wave_overhang_minimum_width`: split waves at narrow necks narrower than this
+- `wave_overhang_min_new_area`: saturation threshold
 
 ### Source
 
@@ -134,10 +132,10 @@ Every step in the flowchart above maps to a specific line in Kaiser's [CustomSup
 | Seed from lower-slice outer wall, shrunk by 2×nozzle | 174 | `seedpoly = Polygon(seedshape).buffer(-2*nozzlesize)` |
 | First ring at r/2 | 403 | `bin1, bin2, shape = offsets(seed_curve, r/2)` |
 | Clip to boundary | 404 | `current_shape = shape.intersection(boundary_polygon)` |
-| Mark on-boundary vertices | 427–434 | `if boundary_polygon.boundary.distance(Point(x,y))<1e-6: isOnBoundary[j] = True` |
-| Direction flip on odd iterations | 440–448 | `if i%2==0: ... else: list(reversed(...))` |
-| Rotate ring start to closest boundary vertex to last_tip | 455–459 | `first_index = closest_point(xlast, ylast, points_filtered, isOnBoundary)` |
-| Extrude vs travel decision | 473–490 | `if (isOnBoundary_filtered[j-1] and isOnBoundary_filtered[j]): # G0 else: # G1` |
+| Mark on-boundary vertices | 427-434 | `if boundary_polygon.boundary.distance(Point(x,y))<1e-6: isOnBoundary[j] = True` |
+| Direction flip on odd iterations | 440-448 | `if i%2==0: ... else: list(reversed(...))` |
+| Rotate ring start to closest boundary vertex to last_tip | 455-459 | `first_index = closest_point(xlast, ylast, points_filtered, isOnBoundary)` |
+| Extrude vs travel decision | 473-490 | `if (isOnBoundary_filtered[j-1] and isOnBoundary_filtered[j]): # G0 else: # G1` |
 | Flow per mm travel = nozzle² / (π/4 · 1.75²) | 56 | `Efactor = nozzlesize**2/(0.25*np.pi*1.75**2)` |
 | Offset previous ring by r | 533 | `a,b,next_shape = offsets(coords, r=r)` |
 | Heal with 0.001mm buffer, clip to boundary | 534 | `current_shape = next_shape.buffer(0.001).intersection(boundary_polygon)` |
@@ -145,9 +143,8 @@ Every step in the flowchart above maps to a specific line in Kaiser's [CustomSup
 
 ### Key parameters
 
-- `wave_overhang_ring_overlap` — fraction by which successive rings overlap (default 0.15 matches Kaiser's reference)
-- `wave_overhang_line_width` — width of each extruded line
-- `wave_overhang_max_iterations` — safety cap on ring count
+- `wave_overhang_ring_overlap`: fraction by which successive rings overlap (default 0.15 matches Kaiser's reference)
+- `wave_overhang_max_iterations`: safety cap on ring count
 
 Flow is fixed at `nozzle²` mm³/mm and doesn't respond to `wave_overhang_flow_ratio`. This is layer-height-independent by design: at 0.2mm layers that equals ~2× standard extrusion, at 0.12mm (Kaiser's tested layer height) it's ~3.3×. Each ring deposits a consistent volume per mm regardless of how thin the slice is, which is what gives the ring-to-ring bond enough material.
 
@@ -167,6 +164,6 @@ Flow is fixed at `nozzle²` mm³/mm and doesn't respond to `wave_overhang_flow_r
 
 ## Which one to pick
 
-Andersons is the battle-tested default — it came from a published-slicer port and handles a wide range of overhang geometries out of the box. Kaiser LaSO is a second angle on the same problem that some people might prefer for highly directional or ridge-like overhangs where strict lateral-offset ring patterns look cleaner than pattern-connected wavefronts.
+Both algorithms are still in active research and get tuned frequently. Neither one is strictly better yet. The honest answer is: try both on your model and see what actually lands for your printer, filament, and geometry.
 
-Try both on your model and upload the results to [waveoverhangs.com](https://waveoverhangs.com) so other people can see what actually worked for your setup.
+Please upload your results (success or failure) at [waveoverhangs.com](https://waveoverhangs.com). Every data point helps shape what the defaults and the per-geometry recommendations should be, and shows other people what has worked for which setup.

--- a/docs/LIMITATIONS.md
+++ b/docs/LIMITATIONS.md
@@ -61,7 +61,7 @@ Practical implication: treat wave overhangs as a tool for **smaller, self-contai
 Things that have helped in testing so far:
 
 - **Material choice:** PLA works best. PETG / ABS / PC are much more likely to delaminate or warp.
-- **Tune the layers above the overhang:** the first 1–3 layers *above* the wave region often do most of the pulling. Slower speed, reduced flow, or extra cooling on those layers can make a visible difference. See `wave_overhang_floor_layers` in [WAVE_OVERHANG_SETTINGS.md](WAVE_OVERHANG_SETTINGS.md).
+- **Tune the layers above the overhang:** the first 1 to 3 layers *above* the wave region often do most of the pulling. Slower speed, reduced flow, or extra cooling on those layers can make a visible difference. See `wave_overhang_floor_layers` in [WAVE_OVERHANG_SETTINGS.md](WAVE_OVERHANG_SETTINGS.md).
 - **Cooling strategy:** default to max part-cooling on the wave layer itself; experiment with the layers above.
 - **Nozzle temperature:** lower end of the material's working range tends to reduce reheating-induced relaxation.
 - **Size limits:** if your overhang is larger than a few cm, consider falling back to traditional support material.

--- a/docs/WAVE_OVERHANG_SETTINGS.md
+++ b/docs/WAVE_OVERHANG_SETTINGS.md
@@ -6,8 +6,8 @@ This document describes every config option added by the wave-overhangs fork of 
 
 1. [What wave overhangs are](#what-wave-overhangs-are)
 2. [How to enable](#how-to-enable)
-3. [Tier 1 — Simple mode](#tier-1--simple-mode)
-4. [Tier 2 — Advanced tuning](#tier-2--advanced-tuning)
+3. [Tier 1: Simple mode](#tier-1-simple-mode)
+4. [Tier 2: Advanced tuning](#tier-2-advanced-tuning)
    - [General](#general)
    - [Geometry](#geometry)
    - [Anchoring](#anchoring)
@@ -39,7 +39,7 @@ Simple mode only shows the 2 top-level controls (master toggle + algorithm). Swi
 
 ---
 
-## Tier 1 — Simple mode
+## Tier 1: Simple mode
 
 Two controls, always visible.
 
@@ -53,18 +53,18 @@ Master on/off switch. When off, none of the other wave-overhang settings have an
 
 Which generator produces the wave pattern.
 
-- **Type:** enum — `andersons` | `kaiser` · **Default:** `andersons`
+- **Type:** enum (`andersons` | `kaiser`) · **Default:** `andersons`
 
 | Choice | What it does | Pick when |
 |---|---|---|
 | **Andersons (wavefront)** | Expands a wavefront outward from the supported edge in fixed-distance steps; each new ring anchors to the previous one. | Most geometries. Robust default, handles complex overhang shapes, good surface quality. |
 | **Kaiser LaSO (lateral offset)** | Detects a seed curve at the root of the overhang and emits progressively offset rings laterally from it. | Long, fairly straight overhang ridges where you want a very regular, directional pattern. |
 
-> **No presets yet.** The tunable space is large and the "right" bundles depend on printer, material, and geometry. Rather than ship opinionated defaults now, we want community test prints to surface what actually works — expect presets to return once there's real data.
+> **No presets yet.** The tunable space is large and the "right" bundles depend on printer, material, and geometry. Rather than ship opinionated defaults now, we want community test prints to surface what actually works. Expect presets to return once there's real data.
 
 ---
 
-## Tier 2 — Advanced tuning
+## Tier 2: Advanced tuning
 
 Every option below appears on the **Wave overhangs** page in Advanced mode, grouped by section.
 
@@ -72,9 +72,9 @@ Every option below appears on the **Wave overhangs** page in Advanced mode, grou
 
 #### `wave_overhang_min_angle`
 
-Soft/metadata-only slope threshold. **Currently not enforced** — retained on the profile for future use.
+Soft/metadata-only slope threshold. **Currently not enforced**; retained on the profile for future use.
 
-- **Type:** float (°) · **Default:** `0` · **Range:** `0 – 90`
+- **Type:** float (°) · **Default:** `0` · **Range:** `0 to 90`
 - **Why it's inert:** the actual slope filter for what becomes an overhang is Orca's upstream *Strength → Detect overhang walls* + *Overhang reverse threshold* pipeline. By the time a region reaches the wave generator, it has already been classified as `erOverhangPerimeter`. A secondary local envelope check (earlier implementations) rejected every legitimate strip because the strip extends roughly one layer-height beyond the supported region by construction. If you want fewer or more overhangs flagged, adjust Orca's upstream thresholds instead.
 - **What to do today:** leave it at `0`. Use *Overhang reverse threshold* (Strength tab) to control which walls the slicer considers overhangs.
 
@@ -82,8 +82,8 @@ Soft/metadata-only slope threshold. **Currently not enforced** — retained on t
 
 Minimum perimeter length (mm) of a detected overhang below which wave generation is skipped.
 
-- **Type:** float (mm) · **Default:** `0.0` · **Range:** `0 – 50`
-- **Tuning:** raise to 2–5 mm to avoid waving tiny overhang fragments (curved corners, small notches) where the travel/seam overhead isn't worth it.
+- **Type:** float (mm) · **Default:** `0.0` · **Range:** `0 to 50`
+- **Tuning:** raise to 2 to 5 mm to avoid waving tiny overhang fragments (curved corners, small notches) where the travel/seam overhead isn't worth it.
 
 ### Geometry
 
@@ -91,14 +91,14 @@ Minimum perimeter length (mm) of a detected overhang below which wave generation
 
 Number of additional concentric outer perimeters drawn inside the overhang region *before* the wave fill.
 
-- **Type:** int · **Default:** `1` · **Range:** `0 – unbounded`
+- **Type:** int · **Default:** `1` · **Range:** `0 to unbounded`
 - **Tuning:** `1` is usually plenty. Raise to `2` for thicker outer shells on structural parts; drop to `0` for pure wave-only regions (experimental).
 
 #### `wave_overhang_pattern`
 
 Travel pattern between wave lines.
 
-- **Type:** enum — `monotonic` | `zigzag` | `smart` · **Default:** `smart`
+- **Type:** enum (`monotonic` | `zigzag` | `smart`) · **Default:** `smart`
 
 | Choice | Behavior |
 |---|---|
@@ -110,14 +110,14 @@ Travel pattern between wave lines.
 
 Extends the wave propagation boundary outward toward kept perimeter lines so the outermost wave sits closer to the shell.
 
-- **Type:** float (mm) · **Default:** `0.1` · **Range:** `0 – unbounded`
-- **Tuning:** raise toward `0.2–0.3` if you see a visible gap between the last wave ring and the outer perimeter. Too high can cause wave lines to print *into* the perimeter.
+- **Type:** float (mm) · **Default:** `0.1` · **Range:** `0 to unbounded`
+- **Tuning:** raise toward `0.2 to 0.3` if you see a visible gap between the last wave ring and the outer perimeter. Too high can cause wave lines to print *into* the perimeter.
 
 #### `wave_overhang_minimum_width`
 
-If a neck in the wave region is narrower than this width, insert a thin split there before propagation so fragile wave branches do not form (Andersons-only — the narrow-region handling from upstream alpha.6, switched to an absolute width in upstream master).
+If a neck in the wave region is narrower than this width, insert a thin split there before propagation so fragile wave branches do not form. Andersons-only; the narrow-region handling from upstream alpha.6, switched to an absolute width in upstream master.
 
-- **Type:** float (mm) · **Default:** `0.7` · **Range:** `0 – unbounded`
+- **Type:** float (mm) · **Default:** `0.7` · **Range:** `0 to unbounded`
 - **Tuning:** raise to split more aggressively if wave rings skip over thin necks between lobes. Lower to `0` to disable splitting.
 
 #### `wave_overhang_line_spacing`
@@ -125,41 +125,41 @@ If a neck in the wave region is narrower than this width, insert a thin split th
 Center-to-center distance between adjacent wave extrusions.
 
 - **Type:** float (mm) · **Default:** `0.35` · **Min:** `0.01`
-- **Tuning:** tighter (0.28–0.30) = denser fill, stronger, slower, risk of over-extrusion on cantilevers. Wider (0.40–0.50) = faster, visible gaps between rings, weaker.
+- **Tuning:** tighter (0.28 to 0.30) = denser fill, stronger, slower, risk of over-extrusion on cantilevers. Wider (0.40 to 0.50) = faster, visible gaps between rings, weaker.
 
 #### `wave_overhang_flow_ratio`
 
 Multiplier applied to the base extrusion flow for wave-overhang lines. Base cross-section is `nozzle_diameter × layer_height`; the final per-mm volume is `base × flow_ratio`.
 
-- **Type:** float (multiplier) · **Default:** `2.0` · **Range:** `0.1 – 3.0`
-- **Why 2.0:** Wave-overhang lines hang in air, not squished against a layer below, so the `width × layer-height` shape does not apply. Empirically they need roughly 2× the base flow to stay continuous — this matches Andersons' reference value of `~0.15 mm²` for a 0.4 mm nozzle.
-- **Why a ratio (not an absolute mm²):** keeps tuning portable across layer heights. A ratio of `2.0` tuned at 0.2 mm layer still makes sense at 0.3 mm layer — the effective cross-section scales with the geometry, instead of silently under-extruding when you change layer height.
+- **Type:** float (multiplier) · **Default:** `2.0` · **Range:** `0.1 to 3.0`
+- **Why 2.0:** Wave-overhang lines hang in air, not squished against a layer below, so the `width × layer-height` shape does not apply. Empirically they need roughly 2× the base flow to stay continuous: this matches Andersons' reference value of `~0.15 mm²` for a 0.4 mm nozzle.
+- **Why a ratio (not an absolute mm²):** keeps tuning portable across layer heights. A ratio of `2.0` tuned at 0.2 mm layer still makes sense at 0.3 mm layer: the effective cross-section scales with the geometry, instead of silently under-extruding when you change layer height.
 - **`1.0`** reverts to Orca's base flow (width × layer-height). This typically under-extrudes wave lines because they aren't actually squished.
 - **Above 2.0** if wave lines still look thin / starved on cantilevered tips.
 - **Below 2.0** if wave lines blob or merge.
 
 **Tuning guide:**
 - Start at `2.0` and print.
-- If wave lines look thin / starved / broken: raise to `2.2 – 2.5`.
-- If wave lines blob or merge: lower to `1.7 – 1.9`.
+- If wave lines look thin / starved / broken: raise to `2.2 to 2.5`.
+- If wave lines blob or merge: lower to `1.7 to 1.9`.
 
 #### `wave_overhang_spacing_mode`
 
 How ring-to-ring step varies across the wave.
 
-- **Type:** enum — `uniform` | `progressive` · **Default:** `uniform`
+- **Type:** enum (`uniform` | `progressive`) · **Default:** `uniform`
 - `uniform` = constant step. `progressive` = tight at the supported root, widens toward the cantilever tip (better anchoring, slightly weaker tip).
 
 #### `wave_overhang_seam_mode`
 
 Direction pattern across successive rings.
 
-- **Type:** enum — `alternating` | `aligned` | `random` · **Default:** `alternating`
+- **Type:** enum (`alternating` | `aligned` | `random`) · **Default:** `alternating`
 
 | Choice | When to use |
 |---|---|
 | `alternating` | Boustrophedon (zig-zag). Minimum travel. Default. |
-| `aligned` | Every ring same direction — more consistent flow, extra travel jumps between rings. |
+| `aligned` | Every ring same direction, for more consistent flow, at the cost of extra travel jumps between rings. |
 | `random` | Scatters seam start points to hide the visible seam on show faces. |
 
 ### Andersons-specific
@@ -170,8 +170,8 @@ These control the Andersons wavefront propagation. No effect when `wave_overhang
 
 Terminate propagation when a new wavefront adds less than this much new area.
 
-- **Type:** float (mm²) · **Default:** `0.01` · **Range:** `0 – 100`
-- Mode: Develop (not in Advanced page by default — expose via Develop mode).
+- **Type:** float (mm²) · **Default:** `0.01` · **Range:** `0 to 100`
+- Mode: Develop (not in Advanced page by default; expose via Develop mode).
 - Andersons' reference: 1e-4 mm² (very small; our default is looser).
 - **Tuning:** lower to keep propagating deep into tight regions; raise to terminate early on diminishing returns.
 
@@ -183,16 +183,16 @@ Only apply when `wave_overhang_algorithm = kaiser`.
 
 Overlap fraction between successive Kaiser offset rings.
 
-- **Type:** float · **Default:** `0.15` · **Range:** `0 – 0.9`
-- **Tuning:** raise (0.25–0.35) for denser, more solid coverage. Lower (0.05–0.10) for faster, more open pattern with visible gaps.
+- **Type:** float · **Default:** `0.15` · **Range:** `0 to 0.9`
+- **Tuning:** raise (0.25 to 0.35) for denser, more solid coverage. Lower (0.05 to 0.10) for faster, more open pattern with visible gaps.
 
 ### Max iterations (shared safety cap)
 
 #### `wave_overhang_max_iterations`
 
-Safety cap on the algorithm's main loop — max wavefronts for Andersons, max rings for Kaiser.
+Safety cap on the algorithm's main loop: max wavefronts for Andersons, max rings for Kaiser.
 
-- **Type:** int · **Default:** `0` (= unlimited) · **Range:** `0 – 500`
+- **Type:** int · **Default:** `0` (= unlimited) · **Range:** `0 to 500`
 - Both algorithms stop naturally when they can't grow further; this is a hard cap for pathological cases or to bound print time on very large overhangs.
 
 ### Speed
@@ -202,14 +202,14 @@ Safety cap on the algorithm's main loop — max wavefronts for Andersons, max ri
 Print speed for wave extrusions.
 
 - **Type:** float (mm/s) · **Default:** `2.0` · **Min:** `0.1`
-- **Tuning:** slower = better cooling and adhesion of cantilever rings. `1.5–2.5` mm/s is the usual useful range. Going above ~5 mm/s defeats the point of wave overhangs.
+- **Tuning:** slower = better cooling and adhesion of cantilever rings. `1.5 to 2.5` mm/s is the usual useful range. Going above ~5 mm/s defeats the point of wave overhangs.
 
 #### `wave_overhang_travel_speed`
 
 Travel speed within wave regions between non-extruding hops.
 
 - **Type:** float (mm/s) · **Default:** `40.0` · **Min:** `1.0`
-- *Save-only in the current build — see [Known limitations](#known-limitations).*
+- *Save-only in the current build; see [Known limitations](#known-limitations).*
 
 ### Cooling
 
@@ -217,21 +217,21 @@ Travel speed within wave regions between non-extruding hops.
 
 Part-cooling fan percentage forced during wave extrusions.
 
-- **Type:** int (%) · **Default:** `100` · **Range:** `0 – 100`
-- *Save-only in the current build — see [Known limitations](#known-limitations).*
-- **Tuning:** keep at 100 % for PLA/PETG. Drop to 40–60 % for ABS/ASA to reduce warping, but note cantilever rings benefit hugely from fast cooling.
+- **Type:** int (%) · **Default:** `100` · **Range:** `0 to 100`
+- *Save-only in the current build; see [Known limitations](#known-limitations).*
+- **Tuning:** keep at 100 % for PLA/PETG. Drop to 40 to 60 % for ABS/ASA to reduce warping, but note cantilever rings benefit hugely from fast cooling.
 
 ### Floor layers
 
 #### `wave_overhang_floor_layers`
 
-Number of solid floor layers placed directly above a wave region. **Authoritative**: this value overrides Orca's `bottom_shell_layers` behavior within the wave shadow — `N` means *exactly* N solid layers above the wave, not N-plus-whatever-bottom-shell-layers-adds.
+Number of solid floor layers placed directly above a wave region. **Authoritative**: this value overrides Orca's `bottom_shell_layers` behavior within the wave shadow. `N` means *exactly* N solid layers above the wave, not N-plus-whatever-bottom-shell-layers-adds.
 
-- **Type:** int · **Default:** `2` · **Range:** `0 – 20`
+- **Type:** int · **Default:** `2` · **Range:** `0 to 20`
 - `N = 0` = zero solid layers above the wave footprint. The layer directly above the wave strip goes straight to sparse infill. Use for max material savings on purely aesthetic overhangs.
 - `N = 2` (default) = two solid-infill layers above the wave before sparse infill resumes. Standard mechanical backing.
 - `N = 3+` = heavier structural cap (slower, more filament, but stiffer).
-- **All N layers are `stInternalSolid` (regular solid infill) — no bridge classification is used, since these layers sit on top of the wave extrusions (which are solid material) rather than spanning air.** Layer L+1 was previously misclassified as `stBottomBridge` and rendered as "Internal bridge" in the preview; that has been fixed so the whole floor window is uniform solid infill.
+- **All N layers are `stInternalSolid` (regular solid infill); no bridge classification is used, since these layers sit on top of the wave extrusions (which are solid material) rather than spanning air.** Layer L+1 was previously misclassified as `stBottomBridge` and rendered as "Internal bridge" in the preview; that has been fixed so the whole floor window is uniform solid infill.
 - **Interaction with `bottom_shell_layers`:** inside the wave shadow, the floor_layers value wins. Outside the wave shadow, Orca's normal shell rules still apply. Implementation: each affected layer gets a `wave_overhang_shadow_polygons` mask that is subtracted from the bottom-shell seed set in both `discover_vertical_shells` and `discover_horizontal_shells`, preventing further solid propagation above N.
 
 ### Support integration
@@ -242,7 +242,7 @@ When wave overhangs are on, generate supports only for overhang areas that *were
 
 - **Type:** bool · **Default:** `false`
 - Explicit support enforcers still apply normally.
-- **Tuning:** turn on for conservative prints where wave coverage might miss edge cases — you get supports only where the wave algorithm gave up.
+- **Tuning:** turn on for conservative prints where wave coverage might miss edge cases; you get supports only where the wave algorithm gave up.
 
 ### Debug
 
@@ -251,7 +251,7 @@ When wave overhangs are on, generate supports only for overhang areas that *were
 Emit `;WAVE_OVERHANG_START` / `;WAVE_OVERHANG_END` comments around wave extrusions and `;WAVE_OVERHANG_CONFIG` banners at region boundaries.
 
 - **Type:** bool · **Default:** `true`
-- Comments only — no effect on the actual print. See [G-code markers](#g-code-markers) for format.
+- Comments only; no effect on the actual print. See [G-code markers](#g-code-markers) for format.
 
 ---
 
@@ -261,22 +261,22 @@ All user-facing options are now plumbed end-to-end. The table below notes mode e
 
 | Option | Status |
 |---|---|
-| `wave_overhang_print_speed` | Fully plumbed — per-path speed override. |
-| `wave_overhang_travel_speed` | Fully plumbed — `GCodeWriter::travel_to_*` extended with optional per-move override, applied around wave extrusions. |
-| `wave_overhang_fan_speed` | Fully plumbed — new `;_WAVE_OVERHANG_FAN_START/END` marker emitted around wave paths and handled in `CoolingBuffer` to drive the part-cooling fan percentage. |
+| `wave_overhang_print_speed` | Fully plumbed; per-path speed override. |
+| `wave_overhang_travel_speed` | Fully plumbed; `GCodeWriter::travel_to_*` extended with optional per-move override, applied around wave extrusions. |
+| `wave_overhang_fan_speed` | Fully plumbed; new `;_WAVE_OVERHANG_FAN_START/END` marker emitted around wave paths and handled in `CoolingBuffer` to drive the part-cooling fan percentage. |
 | `wave_overhang_min_angle` | **Inert (save-only).** Kept on the profile but not enforced; Orca's upstream *Detect overhang walls* + *Overhang reverse threshold* (Strength tab) is the real slope filter. See key description above. |
-| `support_remaining_areas_after_wave_overhangs` | Fully plumbed — residual polygons (wave-uncovered area) are collected and passed into Orca's support generation as enforcer regions. |
+| `support_remaining_areas_after_wave_overhangs` | Fully plumbed; residual polygons (wave-uncovered area) are collected and passed into Orca's support generation as enforcer regions. |
 | `wave_overhang_min_new_area` | Andersons-only, Develop mode only. |
 
 Andersons-only tunables (`min_new_area`, plus wavefront-geometry knobs like `pattern`, `perimeter_overlap`, `minimum_width`, `line_spacing`, `spacing_mode`) only apply when the Andersons algorithm is selected. Kaiser-only tunables (`ring_overlap`) only apply when Kaiser is selected. The shared safety cap `max_iterations` applies to both.
 
-Kaiser's original post-processor places discrete pin-support nubs under overhangs. Those are **not** ported and not planned — use `support_remaining_areas_after_wave_overhangs` with Orca's normal supports instead.
+Kaiser's original post-processor places discrete pin-support nubs under overhangs. Those are **not** ported and not planned; use `support_remaining_areas_after_wave_overhangs` with Orca's normal supports instead.
 
 ---
 
 ## G-code markers
 
-When `wave_overhang_debug_gcode = true` (the default), four kinds of comments appear in the output. They are pure comments — no motion, no effect on the print — but they're invaluable for verifying that waves were emitted and for bug reports (the full wave setup can be reconstructed from the header alone).
+When `wave_overhang_debug_gcode = true` (the default), four kinds of comments appear in the output. They are pure comments (no motion, no effect on the print), but they're invaluable for verifying that waves were emitted and for bug reports (the full wave setup can be reconstructed from the header alone).
 
 **Build context** (once, before any region banners):
 
@@ -289,7 +289,7 @@ When `wave_overhang_debug_gcode = true` (the default), four kinds of comments ap
   filament_flow_ratio=<ratio>
 ```
 
-(Emitted as a single line — split here for readability.)
+(Emitted as a single line; split here for readability.)
 
 **Region banner** (once per wave region, before any extrusion):
 

--- a/docs/images/algorithms/propagation.svg
+++ b/docs/images/algorithms/propagation.svg
@@ -1,12 +1,21 @@
 <svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 820 340" font-family="-apple-system, 'Segoe UI', sans-serif">
   <style>
-    .panel-title { font-size: 18px; font-weight: 600; fill: #0a0a0a; }
-    .label       { font-size: 11px; fill: #6b6b66; }
-    .layer-edge  { fill: none; stroke: #0a0a0a; stroke-width: 1.5; }
+    .panel-title { font-size: 18px; font-weight: 600; fill: #1a1a1a; }
+    .label       { font-size: 11px; fill: #6b6b6b; }
+    .layer-edge  { fill: none; stroke: #1a1a1a; stroke-width: 1.5; }
     .support     { fill: #ececea; }
     .seed        { fill: #ff5e1a; fill-opacity: 0.35; stroke: #ff5e1a; stroke-width: 1.5; }
-    .ring        { fill: none; stroke: #2b3a5c; stroke-width: 1.75; }
-    .caption     { font-size: 12px; fill: #6b6b66; text-anchor: middle; }
+    .ring        { fill: none; stroke: #1e40af; stroke-width: 1.75; }
+    .caption     { font-size: 12px; fill: #6b6b6b; text-anchor: middle; }
+
+    @media (prefers-color-scheme: dark) {
+      .panel-title { fill: #e8e8e8; }
+      .label       { fill: #9a9a95; }
+      .layer-edge  { stroke: #e8e8e8; }
+      .support     { fill: #2a2a2a; }
+      .ring        { stroke: #60a5fa; }
+      .caption     { fill: #9a9a95; }
+    }
   </style>
 
   <!-- Panel titles -->


### PR DESCRIPTION
## Summary
- `propagation.svg` now uses `prefers-color-scheme` so the algorithm diagram stays readable in both GitHub light and dark modes (panel titles, labels, layer edge, support fill, ring color all swap).
- `ALGORITHMS.md`:
  - Dropped the defensive "neither grows inward from outer wall" aside (nobody asked).
  - Rewrote "Which one to pick" to emphasize that both algorithms are still in research and ask readers to upload results, instead of framing Andersons as the battle-tested default.
  - Replaced em/en dashes.
  - Removed the stale `wave_overhang_line_width` bullet (setting removed in v0.2.0).
- `WAVE_OVERHANG_SETTINGS.md` + `LIMITATIONS.md`: repo-wide sweep of em/en dashes (now using hyphens, colons, or "to" for numeric ranges).

## Test plan
- [ ] Open GitHub preview of `docs/ALGORITHMS.md` in dark mode; confirm the SVG panel titles/labels/rings are visible.
- [ ] Same in light mode.
- [ ] `grep -rP '[\x{2013}\x{2014}]' docs/` returns nothing.