### PR TITLE
fix: intercept bridge-classified residuals inside wave-overhang regions

### DIFF
--- a/src/libslic3r/Print.hpp
+++ b/src/libslic3r/Print.hpp
@@ -531,6 +531,11 @@ private:
     // passes to authoritatively set surface types within the wave shadow (N=0 => all
     // stInternal; N>=1 => N layers of uniform stInternalSolid above each wave strip).
     void apply_wave_overhang_floor_layer_authority();
+    // Orca: wave-overhang bridge suppression — when wave_overhangs_instead_of_bridges
+    // is true, reclassify any stBottomBridge / stInternalBridge surfaces inside the
+    // overhang region to stInternalSolid so residuals (small pockets the wave
+    // generator couldn't grow into) print as solid infill instead of bridge pattern.
+    void apply_wave_overhang_bridge_suppression();
     void combine_infill();
     void _generate_support_material();
     std::pair<FillAdaptive::OctreePtr, FillAdaptive::OctreePtr> prepare_adaptive_infill_data(

--- a/src/libslic3r/PrintConfig.cpp
+++ b/src/libslic3r/PrintConfig.cpp
@@ -4614,10 +4614,11 @@ void PrintConfigDef::init_fff_params()
     def = this->add("wave_overhangs_instead_of_bridges", coBool);
     def->label = L("Use wave overhangs instead of bridges");
     def->category = L("Strength");
-    def->tooltip = L("When wave overhangs are enabled, allow them to replace spans that the "
-                     "normal bridge detector would otherwise keep as bridges. Off by default — "
-                     "simple flat spans stay as regular bridges, only concave or holed overhangs "
-                     "get waves. Turn on to force waves everywhere the overhang detector fires.");
+    def->tooltip = L("When wave overhangs are enabled, suppress every bridge classification "
+                     "in this region and fill with solid infill instead. Off by default: simple "
+                     "flat spans stay as regular bridges, only concave or holed overhangs get "
+                     "waves. Turn on to guarantee no bridge patterns anywhere in the region "
+                     "(bottom bridges and internal bridges both become solid infill).");
     def->mode = comAdvanced;
     def->set_default_value(new ConfigOptionBool(false));
 

--- a/src/libslic3r/PrintObject.cpp
+++ b/src/libslic3r/PrintObject.cpp
@@ -1893,19 +1893,22 @@ void PrintObject::apply_wave_overhang_floor_layer_authority()
 
 // ==============================================================================================================
 // === ORCA: Wave-overhang bridge suppression ===================================================================
-// When wave_overhangs + wave_overhangs_instead_of_bridges are on for a region, the wave generator runs on the
-// overhang area at perimeter-gen time, covers what it can (saved in wave_overhang_floor_polygons), and leaves
-// any small pockets it could not grow into as unclaimed residual. process_external_surfaces later sees those
-// residuals as candidate bridges (a pocket above empty space below with supported edges = bridge) and classifies
-// them stBottomBridge / stInternalBridge. The Fill pipeline then prints bridge pattern inside a region that is
-// visually and mechanically a wave-overhang: different flow, different cooling, obvious seam in the preview.
+// When wave_overhangs + wave_overhangs_instead_of_bridges are on for a region, the user has asked for waves to
+// replace bridges in that region entirely. Two kinds of bridge get classified by earlier passes:
 //
-// This pass intercepts those bridges. For each layer in a region with both flags on, we compute the layer's
-// overhang footprint (this_slices minus lower_slices) and reclassify any stBottomBridge / stInternalBridge
-// surfaces overlapping that footprint to stInternalSolid. Outside the overhang footprint, bridges stay bridges.
-// Runs AFTER apply_wave_overhang_floor_layer_authority so the authority pass's decisions (wave layer itself
-// gets no fill; floor layers above are solid) are preserved where they land, and the only surfaces we touch
-// are the residual-bridge ones the authority pass intentionally skipped.
+//   stBottomBridge   : solid over empty space (classic cantilever-style bridge).
+//   stInternalBridge : solid over sparse infill (bridge_over_infill creates these).
+//
+// A geometric "inside the overhang footprint" filter (layer.lslices diff lower.lslices) catches stBottomBridge
+// but misses stInternalBridge, because stInternalBridge sits above sparse infill (still material in lslices).
+// Users saw teal "Internal bridge" patches inside wave layers even with both flags on.
+//
+// Simpler, region-scoped semantics: when the user opts in by setting both flags, suppress ALL bridges in the
+// region. Reclassify stBottomBridge / stInternalBridge to stInternalSolid so the Fill pipeline uses regular
+// solid infill, which bonds cleanly with surrounding wave extrusions and uses the same flow model.
+//
+// Runs AFTER apply_wave_overhang_floor_layer_authority. The authority pass's decisions stay where they land;
+// we only touch surfaces the authority pass kept as bridges.
 // ==============================================================================================================
 void PrintObject::apply_wave_overhang_bridge_suppression()
 {
@@ -1931,45 +1934,15 @@ void PrintObject::apply_wave_overhang_bridge_suppression()
             [this, region_id](const tbb::blocked_range<size_t> &range) {
                 for (size_t idx_layer = range.begin(); idx_layer < range.end(); ++ idx_layer) {
                     m_print->throw_if_canceled();
-                    if (idx_layer == 0) continue; // no lower layer, nothing can be an overhang
-
-                    Layer       *layer = m_layers[idx_layer];
-                    const Layer *lower = m_layers[idx_layer - 1];
-
-                    // Overhang footprint = this-layer outline minus lower-layer outline.
-                    Polygons overhang = diff(to_polygons(layer->lslices), to_polygons(lower->lslices));
-                    if (overhang.empty())
-                        continue;
-
+                    Layer       *layer  = m_layers[idx_layer];
                     LayerRegion *layerm = layer->m_regions[region_id];
                     Surfaces    &surfs  = layerm->fill_surfaces.surfaces;
-                    Surfaces     new_surfaces;
-                    new_surfaces.reserve(surfs.size() + 4);
                     for (Surface &s : surfs) {
-                        if (s.surface_type != stBottomBridge && s.surface_type != stInternalBridge) {
-                            new_surfaces.push_back(std::move(s));
-                            continue;
+                        if (s.surface_type == stBottomBridge || s.surface_type == stInternalBridge) {
+                            s.surface_type = stInternalSolid;
+                            s.bridge_angle = 0;
                         }
-                        Polygons   sp      = to_polygons(s);
-                        ExPolygons inside  = intersection_ex(sp, overhang, ApplySafetyOffset::Yes);
-                        if (inside.empty()) {
-                            new_surfaces.push_back(std::move(s));
-                            continue;
-                        }
-                        ExPolygons outside = diff_ex(sp, to_polygons(inside), ApplySafetyOffset::Yes);
-                        const SurfaceType orig = s.surface_type;
-                        // Reclassify inside-overhang part → solid infill (no bridge pattern).
-                        for (auto &ex_in : union_safety_offset_ex(inside)) {
-                            Surface tmp{s, std::move(ex_in)};
-                            tmp.surface_type = stInternalSolid;
-                            tmp.bridge_angle = 0; // no longer a bridge; clear the orientation hint
-                            new_surfaces.push_back(std::move(tmp));
-                        }
-                        // Keep outside-overhang bridge classification untouched.
-                        for (auto &ex_out : union_safety_offset_ex(outside))
-                            new_surfaces.emplace_back(orig, std::move(ex_out));
                     }
-                    surfs = std::move(new_surfaces);
                 }
             });
         m_print->throw_if_canceled();

--- a/src/libslic3r/PrintObject.cpp
+++ b/src/libslic3r/PrintObject.cpp
@@ -649,6 +649,14 @@ void PrintObject::prepare_infill()
     this->apply_wave_overhang_floor_layer_authority();
     m_print->throw_if_canceled();
 
+    // Orca: wave-overhang bridge suppression. Runs after the floor-layer authority
+    // so bridges the authority pass didn't touch (residual pockets in overhang
+    // areas that the wave generator couldn't grow into) get reclassified to
+    // stInternalSolid. Without this pass those residuals print as bridge pattern
+    // mixed in with waves, which the "instead of bridges" flag is meant to prevent.
+    this->apply_wave_overhang_bridge_suppression();
+    m_print->throw_if_canceled();
+
     // combine fill surfaces to honor the "infill every N layers" option
     this->combine_infill();
     m_print->throw_if_canceled();
@@ -1881,6 +1889,94 @@ void PrintObject::apply_wave_overhang_floor_layer_authority()
 }
 // ==============================================================================================================
 // === ORCA: End of apply_wave_overhang_floor_layer_authority ===================================================
+// ==============================================================================================================
+
+// ==============================================================================================================
+// === ORCA: Wave-overhang bridge suppression ===================================================================
+// When wave_overhangs + wave_overhangs_instead_of_bridges are on for a region, the wave generator runs on the
+// overhang area at perimeter-gen time, covers what it can (saved in wave_overhang_floor_polygons), and leaves
+// any small pockets it could not grow into as unclaimed residual. process_external_surfaces later sees those
+// residuals as candidate bridges (a pocket above empty space below with supported edges = bridge) and classifies
+// them stBottomBridge / stInternalBridge. The Fill pipeline then prints bridge pattern inside a region that is
+// visually and mechanically a wave-overhang: different flow, different cooling, obvious seam in the preview.
+//
+// This pass intercepts those bridges. For each layer in a region with both flags on, we compute the layer's
+// overhang footprint (this_slices minus lower_slices) and reclassify any stBottomBridge / stInternalBridge
+// surfaces overlapping that footprint to stInternalSolid. Outside the overhang footprint, bridges stay bridges.
+// Runs AFTER apply_wave_overhang_floor_layer_authority so the authority pass's decisions (wave layer itself
+// gets no fill; floor layers above are solid) are preserved where they land, and the only surfaces we touch
+// are the residual-bridge ones the authority pass intentionally skipped.
+// ==============================================================================================================
+void PrintObject::apply_wave_overhang_bridge_suppression()
+{
+    bool any = false;
+    for (size_t region_id = 0; region_id < this->num_printing_regions(); ++ region_id) {
+        const PrintRegionConfig &rconf = this->printing_region(region_id).config();
+        if (rconf.wave_overhangs.value && rconf.wave_overhangs_instead_of_bridges.value) {
+            any = true;
+            break;
+        }
+    }
+    if (!any)
+        return;
+
+    BOOST_LOG_TRIVIAL(info) << "Applying wave-overhang bridge suppression...";
+
+    for (size_t region_id = 0; region_id < this->num_printing_regions(); ++ region_id) {
+        const PrintRegionConfig &rconf = this->printing_region(region_id).config();
+        if (!rconf.wave_overhangs.value || !rconf.wave_overhangs_instead_of_bridges.value)
+            continue;
+
+        tbb::parallel_for(tbb::blocked_range<size_t>(0, m_layers.size()),
+            [this, region_id](const tbb::blocked_range<size_t> &range) {
+                for (size_t idx_layer = range.begin(); idx_layer < range.end(); ++ idx_layer) {
+                    m_print->throw_if_canceled();
+                    if (idx_layer == 0) continue; // no lower layer, nothing can be an overhang
+
+                    Layer       *layer = m_layers[idx_layer];
+                    const Layer *lower = m_layers[idx_layer - 1];
+
+                    // Overhang footprint = this-layer outline minus lower-layer outline.
+                    Polygons overhang = diff(to_polygons(layer->lslices), to_polygons(lower->lslices));
+                    if (overhang.empty())
+                        continue;
+
+                    LayerRegion *layerm = layer->m_regions[region_id];
+                    Surfaces    &surfs  = layerm->fill_surfaces.surfaces;
+                    Surfaces     new_surfaces;
+                    new_surfaces.reserve(surfs.size() + 4);
+                    for (Surface &s : surfs) {
+                        if (s.surface_type != stBottomBridge && s.surface_type != stInternalBridge) {
+                            new_surfaces.push_back(std::move(s));
+                            continue;
+                        }
+                        Polygons   sp      = to_polygons(s);
+                        ExPolygons inside  = intersection_ex(sp, overhang, ApplySafetyOffset::Yes);
+                        if (inside.empty()) {
+                            new_surfaces.push_back(std::move(s));
+                            continue;
+                        }
+                        ExPolygons outside = diff_ex(sp, to_polygons(inside), ApplySafetyOffset::Yes);
+                        const SurfaceType orig = s.surface_type;
+                        // Reclassify inside-overhang part → solid infill (no bridge pattern).
+                        for (auto &ex_in : union_safety_offset_ex(inside)) {
+                            Surface tmp{s, std::move(ex_in)};
+                            tmp.surface_type = stInternalSolid;
+                            tmp.bridge_angle = 0; // no longer a bridge; clear the orientation hint
+                            new_surfaces.push_back(std::move(tmp));
+                        }
+                        // Keep outside-overhang bridge classification untouched.
+                        for (auto &ex_out : union_safety_offset_ex(outside))
+                            new_surfaces.emplace_back(orig, std::move(ex_out));
+                    }
+                    surfs = std::move(new_surfaces);
+                }
+            });
+        m_print->throw_if_canceled();
+    }
+}
+// ==============================================================================================================
+// === ORCA: End of apply_wave_overhang_bridge_suppression ======================================================
 // ==============================================================================================================
 
 void PrintObject::process_external_surfaces()


### PR DESCRIPTION
## Summary
Closes the gap where `wave_overhangs_instead_of_bridges=true` did not actually suppress bridges. You showed a layer earlier where wave patterns wrapped around teal "Internal bridge" patches — the wave generator had done its job, but residual pockets it couldn't grow into got reclassified as bridges by `process_external_surfaces`, and the Fill pipeline then painted bridge infill inside the wave region.

## What changed
New pass in `PrintObject.cpp`:

```cpp
void PrintObject::apply_wave_overhang_bridge_suppression()
```

- Runs once in `prepare_infill()`, **after** `apply_wave_overhang_floor_layer_authority()`.
- Gates on: `wave_overhangs == true` AND `wave_overhangs_instead_of_bridges == true` on the region.
- Per layer: computes the overhang footprint as `diff(layer.lslices, lower_layer.lslices)`.
- Scans `fill_surfaces` for any `stBottomBridge` / `stInternalBridge`. Splits each such surface into inside-overhang vs outside-overhang portions; reclassifies the inside portion to `stInternalSolid` (clears `bridge_angle`), leaves outside bridges untouched.
- Parallel per layer via TBB.

Why the intersection split: a single bridge surface can straddle the overhang boundary (part over empty space, part over supported material). We only want to demote the part that sits in the wave's jurisdiction; legitimate bridges outside the overhang footprint keep their bridge treatment.

Why solid instead of sparse or zero fill: bridge-classified residuals are tiny pockets the wave could not cover. Solid infill bonds cleanly with the surrounding wave extrusions, matches their flow model, and needs no cooling-dwell or bridge-speed overrides. Sparse would sag, zero would leave holes.

## Testing plan
- [ ] Slice the same model that produced the teal-patch screenshot. Confirm no `stInternalBridge` / `stBottomBridge` inside wave-overhang layers when both flags are on.
- [ ] Slice with `wave_overhangs_instead_of_bridges=false`. Confirm bridges still appear as before (no regression on the default).
- [ ] Slice a model with a legitimate bridge **outside** any overhang region. Confirm that bridge still prints as bridge (outside-footprint path of the split).
- [ ] G-code preview: area that was teal is now purple (Internal solid infill) on the same layer as the waves.

## Known non-goals for this PR
- The Kaiser slow-slice-at-25% issue reported earlier is unrelated and tracked separately.
- The AppImage libavif/libsharpyuv mismatch on rolling-release distros (#22) is a CI/packaging fix, out of scope here.