### PR TITLE
fix(appimage): resolve libavif/libsharpyuv from host to match user's distro

### DIFF
--- a/scripts/appimage_lib_policy.sh
+++ b/scripts/appimage_lib_policy.sh
@@ -13,7 +13,8 @@ appimage_is_host_library() {
         libgstreamer-1.0.so*|libgst*.so*|libsoup-*.so*|libwebkit2gtk-*.so*|libjavascriptcoregtk-*.so*|libsecret-1.so*|libmanette-0.2.so*|libenchant-2.so*|libhyphen.so*|libtasn1.so*|\
         libfontconfig.so*|libfreetype.so*|libharfbuzz*.so*|libfribidi.so*|libgraphite2.so*|libthai.so*|libdatrie.so*|libepoxy.so*|libpixman-1.so*|\
         libstdc++.so*|libgcc_s.so*|libatomic.so*|libdbus-1.so*|libuuid.so*|libffi.so*|libselinux.so*|libmount.so*|libblkid.so*|libpcre2-*.so*|libsystemd.so*|libcap.so*|libseccomp.so*|\
-        liborc-0.4.so*|libgudev-1.0.so*)
+        liborc-0.4.so*|libgudev-1.0.so*|\
+        libavif.so*|libsharpyuv.so*|libheif.so*|libwebp.so*|libwebpdemux.so*|libwebpmux.so*|libwebpdecoder.so*)
             return 0
             ;;
         *)


### PR DESCRIPTION
Closes #22.

## Summary
Rexor reported the v0.1.2 AppImage segfaulting on CachyOS with:

```
/tmp/.mount_*/bin/orca-slicer: symbol lookup error:
/usr/lib/libavif.so.16: undefined symbol: SharpYuvConvertWithOptions
```

`ldd` on our built binary shows it links both `libavif.so.16` and `libsharpyuv.so.0`. The AppImage bundler copies both from our Ubuntu 24.04 build runner, but the dynamic linker at runtime resolved libavif from the user's `/usr/lib/` anyway. CachyOS's rolling-release libavif needs `SharpYuvConvertWithOptions` from a newer libsharpyuv than what Ubuntu 24.04 ships. Mismatch → segfault.

## Fix
Adding the image-codec stack (`libavif`, `libsharpyuv`, `libheif`, `libwebp`, `libwebpdemux`, `libwebpmux`, `libwebpdecoder`) to `scripts/appimage_lib_policy.sh` so the bundler skips them. Runtime then resolves from the user's system, where the distro ships a matched set.

This mirrors how we already handle `libgtk-*`, `libwebkit2gtk-*`, and other host-tied libraries that need to match what's on the target machine.

## Test plan
- [ ] CI builds and uploads a Linux AppImage.
- [ ] Rexor runs it on CachyOS without the previous symbol error.
- [ ] Same AppImage still launches on Ubuntu 24.04 (where the image-codec stack is universally available).
- [ ] File size of the AppImage drops slightly (image-codec libs no longer in the bundle).

## Known non-impact
- Users on systems missing `libavif.so.16` (e.g., a very old LTS) will now see a clear runtime error instead of a silent bundled fallback. That's arguably better — the error tells them what to install — but if anyone reports it we can revisit.