### PR TITLE
refactor(wave-overhangs): default flow = 0.15 (Andersons reference)

### DIFF
--- a/src/libslic3r/PerimeterGenerator.cpp
+++ b/src/libslic3r/PerimeterGenerator.cpp
@@ -1162,18 +1162,12 @@ void PerimeterGenerator::apply_extra_perimeters(ExPolygons &infill_area)
                                                         this->m_scaled_resolution, *this->object_config, *this->print_config);
 
         if (use_wave_overhangs) {
-            // Wave-overhang lines hang in air. The right flow is a fixed
-            // mm³/mm that scales with nozzle², layer-height-independent
-            // (both algorithms share the same physics; the line is a bead
-            // dropping out of the nozzle, not plastic squished into a slot).
-            // A stored value of 0 means "auto": derive from nozzle² so users
-            // on non-default nozzle sizes get the right default without
-            // per-profile tuning.
-            double flow_mm3_per_mm = this->config->wave_overhang_flow_mm3_per_mm.value;
-            if (flow_mm3_per_mm <= 0.0) {
-                const double nozzle = this->overhang_flow.nozzle_diameter();
-                flow_mm3_per_mm = nozzle * nozzle;
-            }
+            // Wave-overhang lines hang in air, not squished against a layer
+            // below, so the mm³/mm is independent of layer height. Both
+            // algorithms read the same config key and override whatever
+            // flow the generator put on the path initially, so the user
+            // sees one knob with predictable semantics.
+            const double flow_mm3_per_mm = this->config->wave_overhang_flow_mm3_per_mm.value;
             for (ExtrusionPaths &region : extra_perimeters)
                 for (ExtrusionPath &path : region)
                     if (path.wave_overhang)

--- a/src/libslic3r/PrintConfig.cpp
+++ b/src/libslic3r/PrintConfig.cpp
@@ -4680,18 +4680,16 @@ void PrintConfigDef::init_fff_params()
     def->category = L("Strength");
     def->tooltip = L("Volume of plastic extruded per millimetre of wave-overhang line, in mm³/mm. "
                      "Used by both Andersons and Kaiser algorithms.\n\n"
-                     "Wave-overhang lines hang in air instead of being squished against a layer below, so the "
-                     "standard width × layer-height flow model does not apply. The right amount of plastic scales "
-                     "with the square of nozzle diameter: 0.16 for a 0.4 mm nozzle, 0.36 for 0.6 mm, 0.64 for 0.8 mm. "
-                     "This tracks Kaiser's reference and matches Andersons' effective flow at 0.2 mm layer height.\n\n"
-                     "Raise if wave lines look thin or broken; lower if they blob together. Unlike the older "
-                     "flow-ratio knob this value is layer-height-independent by design: the bead is hanging in "
-                     "air, so layer height has no effect on its cross-section.");
+                     "Default 0.15 matches Andersons' published reference for a 0.4 mm nozzle. "
+                     "The bead hangs in air rather than being squished against a layer below, so layer "
+                     "height has no effect on its cross-section. For non-0.4 mm nozzles, scale as "
+                     "0.15 × (nozzle/0.4)²: about 0.09 for 0.3 mm, 0.34 for 0.6 mm, 0.60 for 0.8 mm.\n\n"
+                     "Raise if wave lines look thin or broken; lower if they blob together.");
     def->sidetext = L("mm³/mm");
     def->mode = comAdvanced;
     def->min = 0.02;
     def->max = 1.5;
-    def->set_default_value(new ConfigOptionFloat(0.16));
+    def->set_default_value(new ConfigOptionFloat(0.15));
 
     def = this->add("wave_overhang_print_speed", coFloat);
     def->label = L("Print speed");


### PR DESCRIPTION
## Summary
Changes the default for `wave_overhang_flow_mm3_per_mm` from `0.16` (= `nozzle²` for a 0.4 mm nozzle, Kaiser convention) to `0.15` — the literal value Andersons publishes in his reference implementation at [andersonsjanis/Wave-overhangs](https://github.com/andersonsjanis/Wave-overhangs) (`src/lib/config.ts`, `beadArea: 0.15`).

Practical consequences:
- Value is a **fixed constant**, not a sentinel. UI always shows `0.15` instead of `0` or a magic-auto value. Users can eyeball it and tune from there.
- For non-0.4 mm nozzles, the tooltip documents the scaling rule `0.15 × (nozzle/0.4)²` with worked values for 0.3 mm (0.09), 0.6 mm (0.34), 0.8 mm (0.60).
- Removed the `value <= 0 → auto = nozzle²` fallback in `PerimeterGenerator` since there's no sentinel to resolve anymore.

## Why
Earlier v0.2.1 shipped with `nozzle²` as the default (= 0.16 at 0.4 mm). Daisy pointed out:
1. Andersons's actual published value is 0.15, not `nozzle²`. The "two algorithms converged" argument I used to justify nozzle² was weak — they happen to land within 6%.
2. Switching the nozzle diameter in the UI didn't update the flow value, because the "0 = auto" sentinel was baked in rather than exposed. A literal default removes that confusion entirely.

## Test plan
- [ ] Open Print Settings -> Wave overhangs. "Wave flow" field shows `0.15 mm³/mm`.
- [ ] Tooltip explains the 0.15 default and the nozzle-scaling formula.
- [ ] Slice a sample with Andersons at 0.15 flow. G-code wave paths have `mm3_per_mm = 0.15`.
- [ ] Same with Kaiser. Same value.
- [ ] Build on all 4 platforms.

## This goes into v0.2.1
Part of the same release. Will force-retag v0.2.1 onto the merge commit so the release carries the right default.