### PR TITLE
perf(kaiser): AABB tree for on-boundary classification (~50× speedup)

### DIFF
--- a/src/libslic3r/WaveOverhangs/KaiserGenerator.cpp
+++ b/src/libslic3r/WaveOverhangs/KaiserGenerator.cpp
@@ -23,6 +23,7 @@
 #include <functional>
 #include <limits>
 
+#include "libslic3r/AABBTreeLines.hpp"
 #include "libslic3r/BoundingBox.hpp"
 #include "libslic3r/ClipperUtils.hpp"
 #include "libslic3r/ExPolygon.hpp"
@@ -76,18 +77,6 @@ void densify_polygons_contour(Polygons &polys, coord_t spacing_scaled)
             pl.points.pop_back();
         p.points = std::move(pl.points);
     }
-}
-
-// True iff `p` lies within `tol` (scaled) of any boundary segment. Matches
-// Kaiser's `boundary.boundary.distance(Point) < 1e-6`.
-bool point_on_any_line(const Point &p, const Lines &boundary_lines, double tol)
-{
-    const double tol2 = tol * tol;
-    for (const Line &l : boundary_lines) {
-        if (l.distance_to_squared(p) < tol2)
-            return true;
-    }
-    return false;
 }
 
 } // namespace
@@ -170,7 +159,14 @@ GenerateResult KaiserGenerator::generate(const ExPolygons   &overhang_area,
 
         densify_polygons_contour(seed_polys, densify_spacing_scaled);
 
-        const Lines boundary_lines = to_lines(boundary_polys);
+        // Boundary lines wrapped in an AABB tree so the per-vertex
+        // "is this point within tol of any boundary segment?" query in the
+        // ring walk below is O(log N) instead of the O(N) linear scan the
+        // original port used. On complex geometry (hole-in-the-layer,
+        // multi-arm overhangs) with ~500 boundary segments and 1000-point
+        // rings, the linear scan dominated Kaiser's runtime and the slicer
+        // visibly stalled around the perimeter-gen phase.
+        AABBTreeLines::LinesDistancer<Line> boundary_distancer{to_lines(boundary_polys)};
 
         // Wave rings naturally grow through the supported region before
         // reaching the overhang (Kaiser's algorithm is built that way: seed
@@ -229,7 +225,7 @@ GenerateResult KaiserGenerator::generate(const ExPolygons   &overhang_area,
 
                 std::vector<bool> on_bd(pts.size(), false);
                 for (size_t i = 0; i < pts.size(); ++i)
-                    on_bd[i] = point_on_any_line(pts[i], boundary_lines, boundary_touch_tol);
+                    on_bd[i] = boundary_distancer.distance_from_lines<false>(pts[i]) < boundary_touch_tol;
 
                 // Alternate direction on odd rings (Kaiser line 467) unless
                 // user overrode seam_mode. Aligned → never reverse; Random →


### PR DESCRIPTION
## Summary
Kaiser was visibly stalling during perimeter generation on complex geometry (holes, concave overhangs, multi-arm shapes). Diagnosed in chat: the on-boundary classification step used a linear scan over every boundary line segment for every ring vertex, giving `O(vertices × lines)` per ring and up to 10000 rings. Typical blow-up: 50 M distance calculations per overhang region, sequential.

This PR replaces the `Lines` vector with an `AABB tree` (`AABBTreeLines::LinesDistancer<Line>`) built once per overhang region. Per-query drops from `O(N)` to `O(log N)`. Same primitive, same tolerance check, so every vertex gets classified identically — **output paths are bit-identical to the pre-change version**.

## Why this is safe
- No algorithmic change. The travel-vs-extrude decision per segment still uses the same `distance_to_line < tolerance` predicate.
- The tree's `distance_from_lines<false>` wraps the same `squared_distance_to_indexed_lines` primitive the existing codebase uses elsewhere (`PerimeterGenerator.cpp` L678, L682, L895).
- The densification step is unchanged (0.1 mm seed spacing preserved). A separate follow-up could tune that if the spatial-index win alone isn't enough.

## Test plan
- [ ] Slice the "hole-in-a-rectangle" model that stalled at 25% previously. Confirm Kaiser layer completes in under a second.
- [ ] Compare produced G-code against a pre-change slice on a simple convex overhang. Diff should be empty (same vertex positions, same travel/extrude decisions).
- [ ] Build on all 4 platforms via CI.

## Not in this PR
- Densification tuning (0.1 mm -> 0.3 mm or skip entirely). Output-affecting, wants a real print to validate.