### PR TITLE
fix(wayland): cherry-pick upstream #13303 for device-tab liveview crash

### DIFF
--- a/src/slic3r/GUI/MediaPlayCtrl.cpp
+++ b/src/slic3r/GUI/MediaPlayCtrl.cpp
@@ -32,7 +32,8 @@ static std::map<int, std::string> error_messages = {
     {100, L("The player is not loaded, please click \"play\" button to retry.")},
     {101, L("The player is not loaded, please click \"play\" button to retry.")},
     {102, L("The player is not loaded, please click \"play\" button to retry.")},
-    {103, L("The player is not loaded, please click \"play\" button to retry.")}
+    {103, L("The player is not loaded, please click \"play\" button to retry.")},
+    {104, L("Liveview is unavailable on native Wayland because no compatible GStreamer Wayland video sink was found.")}
 };
 
 namespace Slic3r {

--- a/src/slic3r/GUI/wxMediaCtrl2.cpp
+++ b/src/slic3r/GUI/wxMediaCtrl2.cpp
@@ -3,6 +3,7 @@
 #include "I18N.hpp"
 #include "GUI_App.hpp"
 #include <boost/filesystem/operations.hpp>
+#include <boost/log/trivial.hpp>
 #ifdef __WIN32__
 #include <winuser.h>
 #include <versionhelpers.h>
@@ -11,6 +12,7 @@
 #endif
 
 #ifdef __LINUX__
+#include "LinuxDisplayBackend.hpp"
 #include "Printer/gstbambusrc.h"
 #include <gst/gst.h> // main gstreamer header
 class WXDLLIMPEXP_MEDIA
@@ -19,6 +21,21 @@ class WXDLLIMPEXP_MEDIA
 public:
     GstElement *m_playbin; // GStreamer media element
 };
+
+namespace {
+
+GstElement *make_first_available_sink(const char *const *factories, size_t count)
+{
+    for (size_t i = 0; i < count; ++i) {
+        GstElement *sink = gst_element_factory_make(factories[i], nullptr);
+        if (sink != nullptr)
+            return sink;
+    }
+
+    return nullptr;
+}
+
+} // namespace
 #endif
 
 wxDEFINE_EVENT(EVT_MEDIA_CTRL_STAT, wxCommandEvent);
@@ -43,6 +60,26 @@ wxMediaCtrl2::wxMediaCtrl2(wxWindow *parent)
 #ifdef __LINUX__
     /* Register only after we have created the wxMediaCtrl, since only then are we guaranteed to have fired up Gstreamer's plugin registry. */
     auto playbin = reinterpret_cast<wxGStreamerMediaBackend *>(m_imp)->m_playbin;
+
+#if defined(__WXGTK__)
+    if (Slic3r::GUI::is_running_on_wayland()) {
+        const char *const preferred_wayland_sinks[] = {
+            "gtkwaylandsink",
+            "waylandsink",
+            "glimagesink"
+        };
+        GstElement *video_sink = make_first_available_sink(preferred_wayland_sinks, sizeof(preferred_wayland_sinks) / sizeof(preferred_wayland_sinks[0]));
+        if (video_sink != nullptr) {
+            g_object_set(G_OBJECT(playbin), "video-sink", video_sink, nullptr);
+            gst_object_unref(video_sink);
+            BOOST_LOG_TRIVIAL(info) << "wxMediaCtrl2: configured Wayland-compatible video sink for liveview";
+        } else {
+            m_wayland_video_sink_ready = false;
+            BOOST_LOG_TRIVIAL(warning) << "wxMediaCtrl2: no Wayland-compatible GStreamer sink found; liveview playback disabled to avoid crash";
+        }
+    }
+#endif
+
     g_object_set (G_OBJECT (playbin),
                   "audio-sink", NULL,
                    NULL);
@@ -57,6 +94,28 @@ wxMediaCtrl2::wxMediaCtrl2(wxWindow *parent)
 
 void wxMediaCtrl2::Load(wxURI url)
 {
+#if defined(__LINUX__) && defined(__WXGTK__)
+    if (Slic3r::GUI::is_running_on_wayland() && !m_wayland_video_sink_ready) {
+        static bool notified = false;
+        if (!notified) {
+            CallAfter([] {
+                wxMessageBox(
+                    _L("Liveview is unavailable on native Wayland because no compatible GStreamer Wayland video sink was found. Install a Wayland sink plugin or run OrcaSlicer under X11."),
+                    _L("Error"),
+                    wxOK);
+            });
+            notified = true;
+        }
+
+        m_error = 104;
+        wxMediaEvent event(wxEVT_MEDIA_STATECHANGED);
+        event.SetId(GetId());
+        event.SetEventObject(this);
+        wxPostEvent(this, event);
+        return;
+    }
+#endif
+
 #ifdef __WIN32__
     InvalidateBestSize();
     if (m_imp == nullptr) {

--- a/src/slic3r/GUI/wxMediaCtrl2.h
+++ b/src/slic3r/GUI/wxMediaCtrl2.h
@@ -87,6 +87,7 @@ private:
     wxString m_idle_image;
     int      m_error = 0;
     bool     m_loaded = false;
+    bool     m_wayland_video_sink_ready = true;
     wxSize   m_video_size{16, 9};
 };
 


### PR DESCRIPTION
## Summary
- Cherry-picks [OrcaSlicer/OrcaSlicer#13303](https://github.com/OrcaSlicer/OrcaSlicer/pull/13303) (Ian Bassi): GStreamer video-sink handling for native Wayland so nightly-based sessions stop crashing on the device tab when a BBL printer is selected.
- Upstream PR is still open and includes ~12k lines of scratch files (`status_panel_{commit,prev}.cpp`, `wxmedia_{commit,prev}.cpp`) that the author left at the repo root by mistake. Those are excluded here; only the real fix (`MediaPlayCtrl.cpp`, `wxMediaCtrl2.{cpp,h}`, ~62 lines) is applied.
- Marked in the commit message as a carry-patch so it's easy to drop on the next upstream rebase.

## Motivation
Requested by Rexor [1984] in Discord: nightly Orca (and by extension this fork) crashes on the device tab under Wayland when a BBL printer is active, which blocks sending print jobs. Stable Orca is still on X11 so it isn't affected.

## Test plan
- [ ] CI build passes on \`ubuntu-24.04\`
- [ ] Rexor tests the produced AppImage on Wayland + BBL and confirms the crash is resolved (can't reproduce locally, host is on X11)

*Note:* maintainer is on X11, so this is shipped blind on upstream review. Fix is narrow (video-sink selection), low blast radius.