### PR TITLE
feat(wave-overhangs): end-of-line retraction

### DIFF
--- a/docs/WAVE_OVERHANG_SETTINGS.md
+++ b/docs/WAVE_OVERHANG_SETTINGS.md
@@ -141,6 +141,15 @@ Absolute volume of plastic extruded per millimetre of wave-overhang line. Applie
 - If wave lines look thin / starved / broken: raise by 10 to 20 % (e.g. 0.18 to 0.20 for a 0.4 mm nozzle).
 - If wave lines blob or merge: lower by 10 to 20 % (e.g. 0.13 to 0.14).
 
+#### `wave_overhang_end_retract_length`
+
+Forced retraction (in mm) emitted at the end of every wave-overhang line. Independent of the filament's normal retraction settings.
+
+- **Type:** float (mm) · **Default:** `0.0` · **Range:** `0 to 10`
+- **Why:** wave lines finish in mid-air, so residual nozzle pressure dribbles a small blob that sticks to the next travel path or piles up against the enclosing perimeter. Orca's normal retraction is travel-distance-gated; short inter-wave travels often don't cross the threshold, so most wave line ends never retract.
+- **What it does:** after each wave line, emits `G1 E-<length> F...` (labelled `; WAVE_OVERHANG_END` in the G-code). The next wave line's lead-in travel automatically unretracts via the filament's existing state tracking.
+- **Tuning:** `0` = disabled, use normal retraction heuristic (current behaviour for existing profiles). Start at `0.4 to 0.8 mm` if you see end-of-line blobs or over-extrusion piled against the outer perimeter; raise until the artifacts go away. Above `1.5 mm` you risk under-extrusion at the start of the next line.
+
 #### `wave_overhang_spacing_mode`
 
 How ring-to-ring step varies across the wave.

--- a/src/libslic3r/GCode.cpp
+++ b/src/libslic3r/GCode.cpp
@@ -2554,7 +2554,7 @@ void GCode::_do_export(Print& print, GCodeOutputStream &file, ThumbnailsGenerato
                         " ring_overlap=%.2f"
                         " pattern=%s spacing_mode=%s seam_mode=%s"
                         " perimeter_overlap=%.2f minimum_wave_width=%.2f"
-                        " min_new_area=%.4f"
+                        " min_new_area=%.4f end_retract=%.2f"
                         " nozzle_temp_override=%d min_wave_time=%.2f min_layer_time=%.2f"
                         " wall_loops=%d top_shell_layers=%d bottom_shell_layers=%d"
                         " infill_density=%.0f infill_pattern=%s"
@@ -2575,6 +2575,7 @@ void GCode::_do_export(Print& print, GCodeOutputStream &file, ThumbnailsGenerato
                         rc.wave_overhang_perimeter_overlap.value,
                         rc.wave_overhang_minimum_width.value,
                         rc.wave_overhang_min_new_area.value,
+                        rc.wave_overhang_end_retract_length.value,
                         rc.wave_overhang_nozzle_temp.value,
                         rc.wave_overhang_min_wave_time.value,
                         rc.wave_overhang_min_layer_time.value,
@@ -7152,6 +7153,20 @@ std::string GCode::_extrude(const ExtrusionPath &path, std::string description, 
     }
     if (path.wave_overhang)
         m_inside_wave_overhang = false;
+
+    // Orca: wave-overhang end-of-line retraction. Wave lines finish mid-air,
+    // so leftover nozzle pressure oozes as a visible blob against the next
+    // travel or the enclosing perimeter. Force a retraction after the final
+    // extrusion; the next wave line's lead-in travel will unretract via
+    // Orca's normal state tracking (m_writer tracks retract state on the
+    // filament). A config value of 0 means "let normal travel-distance
+    // retraction heuristics decide" — current behaviour.
+    if (path.wave_overhang) {
+        const double wave_end_retract = m_config.wave_overhang_end_retract_length.value;
+        if (wave_end_retract > 0.) {
+            gcode += m_writer.retract(false, wave_end_retract);
+        }
+    }
 
     if (emit_wave_overhang_markers)
         gcode += "; WAVE_OVERHANG_END\n";

--- a/src/libslic3r/Preset.cpp
+++ b/src/libslic3r/Preset.cpp
@@ -902,7 +902,7 @@ static std::vector<std::string> s_Preset_print_options {
     "wave_overhang_min_angle",
     "wave_overhang_spacing_mode", "wave_overhang_seam_mode",
     "wave_overhang_debug_gcode", "wave_overhang_min_length",
-    "wave_overhang_max_iterations", "wave_overhang_min_new_area",
+    "wave_overhang_max_iterations", "wave_overhang_min_new_area", "wave_overhang_end_retract_length",
     "seam_position", "staggered_inner_seams", "wall_sequence", "is_infill_first", "sparse_infill_density","fill_multiline", "sparse_infill_pattern", "lateral_lattice_angle_1", "lateral_lattice_angle_2", "infill_overhang_angle", "top_surface_pattern", "bottom_surface_pattern",
     "infill_direction", "solid_infill_direction", "counterbore_hole_bridging","infill_shift_step", "sparse_infill_rotate_template", "solid_infill_rotate_template", "symmetric_infill_y_axis","skeleton_infill_density", "infill_lock_depth", "skin_infill_depth", "skin_infill_density",
     "align_infill_direction_to_model", "extra_solid_infills",

--- a/src/libslic3r/PrintConfig.cpp
+++ b/src/libslic3r/PrintConfig.cpp
@@ -4762,6 +4762,21 @@ void PrintConfigDef::init_fff_params()
     def->max = 300;
     def->set_default_value(new ConfigOptionFloat(0.0));
 
+    def = this->add("wave_overhang_end_retract_length", coFloat);
+    def->label = L("End-of-line retract");
+    def->category = L("Quality");
+    def->tooltip = L("Force a retraction of this many mm at the end of every wave-overhang line, "
+                     "independent of the filament's normal retraction settings. Relieves nozzle "
+                     "pressure so residual melt doesn't ooze into the gap between adjacent wave "
+                     "lines or bead up against the enclosing perimeter. The next wave line's lead-in "
+                     "travel automatically unretracts. Set to 0 to rely on Orca's normal travel-"
+                     "distance retraction heuristic.");
+    def->sidetext = L("mm");
+    def->mode = comAdvanced;
+    def->min = 0;
+    def->max = 10;
+    def->set_default_value(new ConfigOptionFloat(0.0));
+
     def = this->add("wave_overhang_floor_layers", coInt);
     def->label = L("Floor layers");
     def->category = L("Strength");

--- a/src/libslic3r/PrintConfig.hpp
+++ b/src/libslic3r/PrintConfig.hpp
@@ -1168,6 +1168,7 @@ PRINT_CONFIG_CLASS_DEFINE(
     ((ConfigOptionFloat,                     wave_overhang_min_length))
     ((ConfigOptionInt,                       wave_overhang_max_iterations))
     ((ConfigOptionFloat,                     wave_overhang_min_new_area))
+    ((ConfigOptionFloat,                     wave_overhang_end_retract_length))
     ((ConfigOptionBool,                      support_remaining_areas_after_wave_overhangs))
     ((ConfigOptionInt, wall_filament))
     ((ConfigOptionFloatOrPercent, inner_wall_line_width))

--- a/src/slic3r/GUI/ConfigManipulation.cpp
+++ b/src/slic3r/GUI/ConfigManipulation.cpp
@@ -980,6 +980,7 @@ void ConfigManipulation::toggle_print_fff_options(DynamicPrintConfig *config, co
         std::string("wave_overhang_algorithm"),
         std::string("wave_overhang_outer_perimeters"),
         std::string("wave_overhang_flow_mm3_per_mm"),
+        std::string("wave_overhang_end_retract_length"),
         std::string("wave_overhang_print_speed"),
         std::string("wave_overhang_travel_speed"),
         std::string("wave_overhang_fan_speed"),

--- a/src/slic3r/GUI/Tab.cpp
+++ b/src/slic3r/GUI/Tab.cpp
@@ -2423,6 +2423,7 @@ void TabPrint::build()
         // so empty-algorithm sections don't render as blank headers.
         optgroup = page->new_optgroup(L("Algorithm tuning"), L"param_overhang");
         optgroup->append_single_option_line("wave_overhang_flow_mm3_per_mm");
+        optgroup->append_single_option_line("wave_overhang_end_retract_length");
         optgroup->append_single_option_line("wave_overhang_ring_overlap");
         optgroup->append_single_option_line("wave_overhang_pattern");
         optgroup->append_single_option_line("wave_overhang_perimeter_overlap");


### PR DESCRIPTION
## Summary
- New config `wave_overhang_end_retract_length` (mm, default 0)
- When >0, forces a retraction after every wave line so residual nozzle pressure doesn't ooze into the next travel or pile up against the enclosing perimeter
- Normal Orca retraction only fires when travel distance exceeds a threshold, which short inter-wave travels often don't, so most wave line ends currently never retract
- Emitted via `m_writer.retract(false, length)`; next extrude automatically unretracts via the filament's state tracking
- Added to the `WAVE_OVERHANG_CONFIG` debug header as `end_retract=` so waveoverhangs.com can parse and display it
- Setting wired into the Wave Overhangs tab (Algorithm tuning group, next to flow_mm3_per_mm)
- Documented in `docs/WAVE_OVERHANG_SETTINGS.md`

## Motivation
On submission #22 (Bambu A1 mini, PLA, 0.15 mm³/mm default) the biggest visible defects are:
1. End-of-line blobs where each wave line meets the perimeter
2. Over-extrusion piled against the outer perimeter boundary

Both are downstream of residual melt pressure at line ends. This knob lets users dial it out empirically.

## Test plan
- [x] CI builds pass (Linux/macOS/Windows)
- [ ] Download artifact, open the slicer, confirm the new setting appears under Wave Overhangs › Algorithm tuning
- [ ] Slice a test overhang with end_retract_length=0.8 on PLA, inspect G-code for `G1 E-0.8 F...` just before `; WAVE_OVERHANG_END`
- [ ] Print and compare line-end quality vs. a baseline with end_retract_length=0