### PR TITLE
fix(wave-overhangs): carve wall_loops out of wave-covered region

### DIFF
--- a/docs/WAVE_OVERHANG_SETTINGS.md
+++ b/docs/WAVE_OVERHANG_SETTINGS.md
@@ -89,10 +89,15 @@ Minimum perimeter length (mm) of a detected overhang below which wave generation
 
 #### `wave_overhang_outer_perimeters`
 
-Number of additional concentric outer perimeters drawn inside the overhang region *before* the wave fill.
+Number of outer perimeters preserved inside the overhang region. Everything inward of that becomes wave pattern. Independent of *Strength > Walls* (`wall_loops`): if you set this to `1`, the overhang zone always has one outer wall + wave regardless of how many walls the rest of the object prints.
 
 - **Type:** int · **Default:** `1` · **Range:** `0 to unbounded`
-- **Tuning:** `1` is usually plenty. Raise to `2` for thicker outer shells on structural parts; drop to `0` for pure wave-only regions (experimental).
+- **How it works:** the overhang region of the layer is computed from the island geometry (island − lower_slices). The outermost `N` normal perimeters in that region are kept untouched; inner perimeters are clipped away and replaced by wave pattern. The wave starts exactly where the preserved walls end, so there is no gap between them.
+- **Interaction with `wall_loops`:** the setting is capped at the effective wall count for the layer. Two cases matter:
+  - If you set `wave_overhang_outer_perimeters = 5` but `wall_loops = 2`, only 2 walls exist, so effectively 2 are preserved and wave fills everything inside.
+  - On topmost layers with `only_one_wall_top` enabled, only 1 wall is generated regardless of `wall_loops`, so the cap pulls effective preservation down to 1.
+  Without the cap the wave region would be over-shrunk and the slicer would fill the leftover band with bridge paths instead of wave.
+- **Tuning:** `1` is usually plenty. Raise to `2` or `3` for thicker outer shells on structural parts. Set to `0` for pure wave from the model boundary inward (no outer perimeter, experimental).
 
 #### `wave_overhang_pattern`
 

--- a/src/libslic3r/PerimeterGenerator.cpp
+++ b/src/libslic3r/PerimeterGenerator.cpp
@@ -1233,18 +1233,22 @@ void PerimeterGenerator::apply_extra_perimeters(ExPolygons &infill_area, const E
         // Semantic: wave_overhang_outer_perimeters = N means "keep N outermost normal
         // perimeters inside the overhang zone, replace the rest with wave pattern". The wave
         // itself produces only the pattern (additional_shell_count=0); the N preserved normal
-        // perimeters are the walls. To avoid a gap between the kept perimeters and where the
-        // wave starts, expand infill_area outward by (wall_loops - N) * perimeter_spacing so
-        // the wave reaches exactly where the preserved perimeters end.
+        // perimeters are the walls.
+        //
+        // Compute the wave's input region from the island geometry directly: island shrunk
+        // inward by N * perimeter_spacing. This is the area starting exactly where the N
+        // preserved walls end. Deriving from the island (not from expanding infill_area by
+        // wall_loops - N) makes this robust for layers where the effective wall count differs
+        // from config->wall_loops - e.g. only_one_wall_top on the topmost layer generates
+        // one wall regardless of wall_loops, and expanding by (wall_loops - N) over-extends
+        // past the single wall and glitches the wave.
         const int wave_outer = std::max(0, this->config->wave_overhang_outer_perimeters.value);
-        const int wall_loops = this->config->wall_loops;
         ExPolygons wave_infill = infill_area;
         if (use_wave_overhangs) {
-            const int extra = std::max(0, wall_loops - wave_outer);
-            if (extra > 0) {
-                const float expand_by = float(this->perimeter_flow.scaled_spacing()) * float(extra);
-                wave_infill = offset_ex(infill_area, expand_by);
-            }
+            const float inset = float(this->perimeter_flow.scaled_spacing()) * float(wave_outer);
+            wave_infill = wave_outer > 0
+                ? offset_ex(ExPolygons{island_region}, -inset)
+                : ExPolygons{island_region};
         }
 
         auto [extra_perimeters, filled_area] = use_wave_overhangs
@@ -1276,16 +1280,15 @@ void PerimeterGenerator::apply_extra_perimeters(ExPolygons &infill_area, const E
                 new_perimeters.append(paths);
             }
             if (use_wave_overhangs && !filled_area.empty()) {
-                // Clip normal perimeters whose inset_idx >= wave_outer inside the geometric
-                // overhang zone, gated by proximity to where the wave actually covered so
-                // bridgeable overhangs the wave chose to skip are left alone.
-                const Polygons island_polys = to_polygons(ExPolygons{island_region});
-                const Polygons overhang_zone = diff(island_polys, this->lower_slices_polygons());
-                const coord_t reach = coord_t(scale_(EXTERNAL_INFILL_MARGIN));
-                const Polygons clip_region = intersection(expand(filled_area, reach, jtRound, 0.),
-                                                          overhang_zone);
+                // Clip normal perimeters whose inset_idx >= wave_outer anywhere the wave
+                // actually laid extrusions. Using filled_area directly (not intersected with
+                // the geometric overhang zone) catches the small anchor band where the wave
+                // reaches into the supported material for stability - otherwise the walls
+                // keep running through that strip and visibly overlap the wave at overhang
+                // corners. Bridgeable overhangs the wave chose to skip are unaffected because
+                // filled_area is empty there.
                 ExtrusionEntityCollection clipped =
-                    clip_inner_perimeters_in_zone(*this_islands_perimeters, clip_region, wave_outer);
+                    clip_inner_perimeters_in_zone(*this_islands_perimeters, filled_area, wave_outer);
                 new_perimeters.append(std::move(clipped.entities));
             } else {
                 new_perimeters.append(this_islands_perimeters->entities);

--- a/src/libslic3r/PerimeterGenerator.cpp
+++ b/src/libslic3r/PerimeterGenerator.cpp
@@ -1226,23 +1226,18 @@ static ExtrusionEntityCollection clip_perimeters_outside_of(const ExtrusionEntit
     return out;
 }
 
-void PerimeterGenerator::apply_extra_perimeters(ExPolygons &infill_area, const ExPolygon &island_region)
+void PerimeterGenerator::apply_extra_perimeters(ExPolygons &infill_area)
 {
     const bool use_wave_overhangs = this->config->wave_overhangs;
     const bool gate_extra_perims  = this->config->extra_perimeters_on_overhangs || use_wave_overhangs;
     if (!m_spiral_vase && this->lower_slices != nullptr && this->config->detect_overhang_wall && gate_extra_perims &&
         this->config->wall_loops > 0 && this->layer_id > this->object_config->raft_layers) {
-        // For wave overhangs, feed the full pre-perimeter island to the generator so the wave
-        // sees the complete overhang zone, not just the wall-shrunk leftover. This lets
-        // wave_overhang_outer_perimeters work independently of wall_loops. The legacy
-        // extra_perimeters_on_overhangs path still gets the post-perimeter infill_area since
-        // it's meant to add perimeters on top of existing ones.
-        ExPolygons wave_input_area;
-        if (use_wave_overhangs)
-            wave_input_area.emplace_back(island_region);
-
+        // Keep passing the post-perimeter infill_area to the wave generator. Passing the full
+        // island would trip should_generate_waves_for_region's bridgeability check (perfect
+        // anchors on a big region = "bridgeable" = wave skipped = normal perimeters survive),
+        // which regresses the very case this change is meant to fix.
         auto [extra_perimeters, filled_area] = use_wave_overhangs
-            ? generate_wave_overhang_paths(wave_input_area, this->lower_slices_polygons(),
+            ? generate_wave_overhang_paths(infill_area, this->lower_slices_polygons(),
                                            this->config->wall_loops, *this->config,
                                            this->overhang_flow, this->m_scaled_resolution)
             : generate_extra_perimeters_over_overhangs(infill_area, this->lower_slices_polygons(),
@@ -1868,7 +1863,7 @@ void PerimeterGenerator::process_classic()
         }
         this->fill_surfaces->append(infill_exp, stInternal);
 
-        apply_extra_perimeters(infill_exp, surface.expolygon);
+        apply_extra_perimeters(infill_exp);
 
         // BBS: get the no-overlap infill expolygons
         {
@@ -2725,7 +2720,7 @@ void PerimeterGenerator::process_arachne()
         }
         this->fill_surfaces->append(infill_exp, stInternal);
 
-        apply_extra_perimeters(infill_exp, surface.expolygon);
+        apply_extra_perimeters(infill_exp);
 
         // BBS: get the no-overlap infill expolygons
         {

--- a/src/libslic3r/PerimeterGenerator.cpp
+++ b/src/libslic3r/PerimeterGenerator.cpp
@@ -1236,17 +1236,25 @@ void PerimeterGenerator::apply_extra_perimeters(ExPolygons &infill_area, const E
         // perimeters are the walls.
         //
         // Compute the wave's input region from the island geometry directly: island shrunk
-        // inward by N * perimeter_spacing. This is the area starting exactly where the N
-        // preserved walls end. Deriving from the island (not from expanding infill_area by
-        // wall_loops - N) makes this robust for layers where the effective wall count differs
-        // from config->wall_loops - e.g. only_one_wall_top on the topmost layer generates
-        // one wall regardless of wall_loops, and expanding by (wall_loops - N) over-extends
-        // past the single wall and glitches the wave.
+        // inward by effective_outer * perimeter_spacing, where effective_outer is capped at
+        // the number of walls that will actually be generated for this layer. Capping matters
+        // because:
+        //   - If the user sets wave_outer > wall_loops, only wall_loops walls exist, so the
+        //     wave should start where those walls end (wall_loops * spacing), not further in.
+        //   - Topmost layers with only_one_wall_top generate a single wall regardless of
+        //     wall_loops, so the cap pulls effective_outer down to 1 there.
+        // Without the cap the wave region is over-shrunk, leaving a strip of overhang that
+        // neither the walls nor the wave covers - the slicer fills it with bridge paths.
         const int wave_outer = std::max(0, this->config->wave_overhang_outer_perimeters.value);
+        int effective_wall_loops = this->config->wall_loops;
+        const bool is_topmost_layer = (this->upper_slices == nullptr);
+        if (is_topmost_layer && this->config->only_one_wall_top && effective_wall_loops > 1)
+            effective_wall_loops = 1;
+        const int effective_outer = std::min(wave_outer, effective_wall_loops);
         ExPolygons wave_infill = infill_area;
         if (use_wave_overhangs) {
-            const float inset = float(this->perimeter_flow.scaled_spacing()) * float(wave_outer);
-            wave_infill = wave_outer > 0
+            const float inset = float(this->perimeter_flow.scaled_spacing()) * float(effective_outer);
+            wave_infill = effective_outer > 0
                 ? offset_ex(ExPolygons{island_region}, -inset)
                 : ExPolygons{island_region};
         }

--- a/src/libslic3r/PerimeterGenerator.cpp
+++ b/src/libslic3r/PerimeterGenerator.cpp
@@ -1086,22 +1086,14 @@ static std::tuple<std::vector<ExtrusionPaths>, Polygons> generate_wave_overhang_
     ExPolygons               infill_area,
     const Polygons          &lower_slices_polygons,
     int                      perimeter_count,
+    int                      additional_shell_count_override,
     const PrintRegionConfig &region_config,
     const Flow              &overhang_flow,
     double                   scaled_resolution)
 {
-    // wave_overhang_outer_perimeters = total perimeter passes to keep over the
-    // wave region. Independent of Quality-tab wall_loops: the wave carves its
-    // own region and the caller clips normal perimeters out of it, so users
-    // get exactly this many walls in the overhang zone regardless of how many
-    // walls the rest of the object runs. The wave generator expects the
-    // *extra* shells beyond the innermost 1 via additional_shell_count.
-    const int desired_wave_perimeters = std::max(0, region_config.wave_overhang_outer_perimeters.value);
-    const int additional_shell_count  = std::max(0, desired_wave_perimeters - 1);
-
     WaveOverhangs::CommonParams params;
     params.perimeter_count        = perimeter_count;
-    params.additional_shell_count = additional_shell_count;
+    params.additional_shell_count = std::max(0, additional_shell_count_override);
     params.line_spacing           = region_config.wave_overhang_line_spacing.value;
     params.line_width             = overhang_flow.nozzle_diameter();  // Always match nozzle; line_width != nozzle has no sensible regime in air.
     params.overhang_flow          = overhang_flow;
@@ -1146,14 +1138,14 @@ static std::tuple<std::vector<ExtrusionPaths>, Polygons> generate_wave_overhang_
     return { std::move(res.paths), std::move(res.residual) };
 }
 
-// Clip normal perimeters so they stay OUTSIDE `clip_region`. Used when wave
-// overhangs take over the overhang zone: the object's wall_loops should not
-// print into that area alongside the wave - only the wave's own shells should
-// live there. Closed loops that survive untouched are kept as ExtrusionLoops;
-// loops that get cut become ExtrusionMultiPaths (ordered, but open).
-// Per-path role / width / height / mm³-per-mm are preserved.
-static ExtrusionEntityCollection clip_perimeters_outside_of(const ExtrusionEntityCollection &src,
-                                                            const Polygons                  &clip_region)
+// Replace any entity in `src` whose inset_idx >= preserve_outer_count AND whose bbox
+// overlaps `clip_region` by the diff of its polyline against clip_region. Entities with
+// inset_idx < preserve_outer_count are left alone (used to keep the outer N normal
+// perimeters intact at the model boundary). Closed loops that get cut become
+// ExtrusionMultiPaths; per-path role / width / height / mm³-per-mm are preserved.
+static ExtrusionEntityCollection clip_inner_perimeters_in_zone(const ExtrusionEntityCollection &src,
+                                                               const Polygons                  &clip_region,
+                                                               int                              preserve_outer_count)
 {
     ExtrusionEntityCollection out;
     out.no_sort = src.no_sort;
@@ -1164,7 +1156,7 @@ static ExtrusionEntityCollection clip_perimeters_outside_of(const ExtrusionEntit
     BoundingBox clip_bbox = get_extents(clip_region);
     clip_bbox.offset(SCALED_EPSILON);
 
-    auto entity_disjoint = [&](const ExtrusionEntity *e) {
+    auto disjoint = [&](const ExtrusionEntity *e) {
         Points pts;
         e->collect_points(pts);
         if (pts.empty())
@@ -1190,7 +1182,12 @@ static ExtrusionEntityCollection clip_perimeters_outside_of(const ExtrusionEntit
     for (const ExtrusionEntity *ent : src.entities) {
         if (!ent)
             continue;
-        if (entity_disjoint(ent)) {
+        // Preserve outer N perimeters (and anything that doesn't track inset_idx) intact.
+        if (ent->inset_idx < 0 || ent->inset_idx < preserve_outer_count) {
+            out.append(*ent);
+            continue;
+        }
+        if (disjoint(ent)) {
             out.append(*ent);
             continue;
         }
@@ -1199,13 +1196,17 @@ static ExtrusionEntityCollection clip_perimeters_outside_of(const ExtrusionEntit
             clip_paths(loop->paths, kept_paths);
             if (kept_paths.empty())
                 continue;
-            out.append(ExtrusionMultiPath(std::move(kept_paths)));
+            ExtrusionMultiPath mp(std::move(kept_paths));
+            mp.inset_idx = ent->inset_idx;
+            out.append(std::move(mp));
         } else if (const ExtrusionMultiPath *mp = dynamic_cast<const ExtrusionMultiPath*>(ent)) {
             ExtrusionPaths kept_paths;
             clip_paths(mp->paths, kept_paths);
             if (kept_paths.empty())
                 continue;
-            out.append(ExtrusionMultiPath(std::move(kept_paths)));
+            ExtrusionMultiPath new_mp(std::move(kept_paths));
+            new_mp.inset_idx = ent->inset_idx;
+            out.append(std::move(new_mp));
         } else if (const ExtrusionPath *path = dynamic_cast<const ExtrusionPath*>(ent)) {
             Polylines kept = diff_pl(Polylines{path->polyline}, clip_region);
             for (Polyline &pl : kept) {
@@ -1213,12 +1214,9 @@ static ExtrusionEntityCollection clip_perimeters_outside_of(const ExtrusionEntit
                     continue;
                 ExtrusionPath np(*path);
                 np.polyline = std::move(pl);
+                np.inset_idx = ent->inset_idx;
                 out.append(std::move(np));
             }
-        } else if (const ExtrusionEntityCollection *coll = dynamic_cast<const ExtrusionEntityCollection*>(ent)) {
-            ExtrusionEntityCollection clipped = clip_perimeters_outside_of(*coll, clip_region);
-            if (!clipped.empty())
-                out.append(std::move(clipped));
         } else {
             out.append(*ent);
         }
@@ -1232,13 +1230,27 @@ void PerimeterGenerator::apply_extra_perimeters(ExPolygons &infill_area, const E
     const bool gate_extra_perims  = this->config->extra_perimeters_on_overhangs || use_wave_overhangs;
     if (!m_spiral_vase && this->lower_slices != nullptr && this->config->detect_overhang_wall && gate_extra_perims &&
         this->config->wall_loops > 0 && this->layer_id > this->object_config->raft_layers) {
-        // Keep passing the post-perimeter infill_area to the wave generator. Passing the full
-        // island would trip should_generate_waves_for_region's bridgeability check (perfect
-        // anchors on a big region = "bridgeable" = wave skipped = normal perimeters survive),
-        // which regresses the very case this change is meant to fix.
+        // Semantic: wave_overhang_outer_perimeters = N means "keep N outermost normal
+        // perimeters inside the overhang zone, replace the rest with wave pattern". The wave
+        // itself produces only the pattern (additional_shell_count=0); the N preserved normal
+        // perimeters are the walls. To avoid a gap between the kept perimeters and where the
+        // wave starts, expand infill_area outward by (wall_loops - N) * perimeter_spacing so
+        // the wave reaches exactly where the preserved perimeters end.
+        const int wave_outer = std::max(0, this->config->wave_overhang_outer_perimeters.value);
+        const int wall_loops = this->config->wall_loops;
+        ExPolygons wave_infill = infill_area;
+        if (use_wave_overhangs) {
+            const int extra = std::max(0, wall_loops - wave_outer);
+            if (extra > 0) {
+                const float expand_by = float(this->perimeter_flow.scaled_spacing()) * float(extra);
+                wave_infill = offset_ex(infill_area, expand_by);
+            }
+        }
+
         auto [extra_perimeters, filled_area] = use_wave_overhangs
-            ? generate_wave_overhang_paths(infill_area, this->lower_slices_polygons(),
-                                           this->config->wall_loops, *this->config,
+            ? generate_wave_overhang_paths(wave_infill, this->lower_slices_polygons(),
+                                           this->config->wall_loops, /*additional_shell_count=*/0,
+                                           *this->config,
                                            this->overhang_flow, this->m_scaled_resolution)
             : generate_extra_perimeters_over_overhangs(infill_area, this->lower_slices_polygons(),
                                                         this->config->wall_loops, this->overhang_flow,
@@ -1264,23 +1276,16 @@ void PerimeterGenerator::apply_extra_perimeters(ExPolygons &infill_area, const E
                 new_perimeters.append(paths);
             }
             if (use_wave_overhangs && !filled_area.empty()) {
-                // Clip normal perimeters out of the island's overhang zone so only the wave's
-                // output lives there. We don't clip against filled_area directly because the
-                // wave's internal anchor shrink and the wall_loops shrink of infill_area
-                // leave filled_area smaller than the real overhang — the outer wall_loops
-                // rings would survive at the overhang edge. Instead, carve the full geometric
-                // overhang (island - lower_slices) and gate it by proximity to where the
-                // wave actually covered, so bridgeable overhangs that the wave chose to skip
-                // keep their perimeters intact.
-                Polygons island_polys = to_polygons(ExPolygons{island_region});
-                Polygons overhang_zone = diff(island_polys, this->lower_slices_polygons());
-                // Generous reach from the wave's footprint so we catch the full overhang
-                // band the wave was meant to service. EXTERNAL_INFILL_MARGIN matches the
-                // anchor-size ceiling in the wave generator.
+                // Clip normal perimeters whose inset_idx >= wave_outer inside the geometric
+                // overhang zone, gated by proximity to where the wave actually covered so
+                // bridgeable overhangs the wave chose to skip are left alone.
+                const Polygons island_polys = to_polygons(ExPolygons{island_region});
+                const Polygons overhang_zone = diff(island_polys, this->lower_slices_polygons());
                 const coord_t reach = coord_t(scale_(EXTERNAL_INFILL_MARGIN));
-                Polygons clip_region = intersection(expand(filled_area, reach, jtRound, 0.),
-                                                    overhang_zone);
-                ExtrusionEntityCollection clipped = clip_perimeters_outside_of(*this_islands_perimeters, clip_region);
+                const Polygons clip_region = intersection(expand(filled_area, reach, jtRound, 0.),
+                                                          overhang_zone);
+                ExtrusionEntityCollection clipped =
+                    clip_inner_perimeters_in_zone(*this_islands_perimeters, clip_region, wave_outer);
                 new_perimeters.append(std::move(clipped.entities));
             } else {
                 new_perimeters.append(this_islands_perimeters->entities);

--- a/src/libslic3r/PerimeterGenerator.cpp
+++ b/src/libslic3r/PerimeterGenerator.cpp
@@ -1091,12 +1091,12 @@ static std::tuple<std::vector<ExtrusionPaths>, Polygons> generate_wave_overhang_
     double                   scaled_resolution)
 {
     // wave_overhang_outer_perimeters = total perimeter passes to keep over the
-    // wave region, capped at the region's own perimeter count. The wave
-    // generator expects the *extra* shells beyond the innermost 1 via
-    // additional_shell_count, so subtract 1, not perimeter_count (the old
-    // formula always resolved to 0 and silently ignored the setting).
-    const int desired_wave_perimeters = std::min(region_config.wave_overhang_outer_perimeters.value,
-                                                 perimeter_count);
+    // wave region. Independent of Quality-tab wall_loops: the wave carves its
+    // own region and the caller clips normal perimeters out of it, so users
+    // get exactly this many walls in the overhang zone regardless of how many
+    // walls the rest of the object runs. The wave generator expects the
+    // *extra* shells beyond the innermost 1 via additional_shell_count.
+    const int desired_wave_perimeters = std::max(0, region_config.wave_overhang_outer_perimeters.value);
     const int additional_shell_count  = std::max(0, desired_wave_perimeters - 1);
 
     WaveOverhangs::CommonParams params;
@@ -1146,15 +1146,103 @@ static std::tuple<std::vector<ExtrusionPaths>, Polygons> generate_wave_overhang_
     return { std::move(res.paths), std::move(res.residual) };
 }
 
-void PerimeterGenerator::apply_extra_perimeters(ExPolygons &infill_area)
+// Clip normal perimeters so they stay OUTSIDE `clip_region`. Used when wave
+// overhangs take over the overhang zone: the object's wall_loops should not
+// print into that area alongside the wave - only the wave's own shells should
+// live there. Closed loops that survive untouched are kept as ExtrusionLoops;
+// loops that get cut become ExtrusionMultiPaths (ordered, but open).
+// Per-path role / width / height / mm³-per-mm are preserved.
+static ExtrusionEntityCollection clip_perimeters_outside_of(const ExtrusionEntityCollection &src,
+                                                            const Polygons                  &clip_region)
+{
+    ExtrusionEntityCollection out;
+    out.no_sort = src.no_sort;
+    if (clip_region.empty()) {
+        out.append(src.entities);
+        return out;
+    }
+    BoundingBox clip_bbox = get_extents(clip_region);
+    clip_bbox.offset(SCALED_EPSILON);
+
+    auto entity_disjoint = [&](const ExtrusionEntity *e) {
+        Points pts;
+        e->collect_points(pts);
+        if (pts.empty())
+            return true;
+        BoundingBox b(pts);
+        return !clip_bbox.overlap(b);
+    };
+
+    auto clip_paths = [&](const ExtrusionPaths &src_paths, ExtrusionPaths &dst_paths) {
+        dst_paths.reserve(dst_paths.size() + src_paths.size());
+        for (const ExtrusionPath &p : src_paths) {
+            Polylines kept = diff_pl(Polylines{p.polyline}, clip_region);
+            for (Polyline &pl : kept) {
+                if (pl.points.size() < 2)
+                    continue;
+                ExtrusionPath np(p);
+                np.polyline = std::move(pl);
+                dst_paths.emplace_back(std::move(np));
+            }
+        }
+    };
+
+    for (const ExtrusionEntity *ent : src.entities) {
+        if (!ent)
+            continue;
+        if (entity_disjoint(ent)) {
+            out.append(*ent);
+            continue;
+        }
+        if (const ExtrusionLoop *loop = dynamic_cast<const ExtrusionLoop*>(ent)) {
+            ExtrusionPaths kept_paths;
+            clip_paths(loop->paths, kept_paths);
+            if (kept_paths.empty())
+                continue;
+            out.append(ExtrusionMultiPath(std::move(kept_paths)));
+        } else if (const ExtrusionMultiPath *mp = dynamic_cast<const ExtrusionMultiPath*>(ent)) {
+            ExtrusionPaths kept_paths;
+            clip_paths(mp->paths, kept_paths);
+            if (kept_paths.empty())
+                continue;
+            out.append(ExtrusionMultiPath(std::move(kept_paths)));
+        } else if (const ExtrusionPath *path = dynamic_cast<const ExtrusionPath*>(ent)) {
+            Polylines kept = diff_pl(Polylines{path->polyline}, clip_region);
+            for (Polyline &pl : kept) {
+                if (pl.points.size() < 2)
+                    continue;
+                ExtrusionPath np(*path);
+                np.polyline = std::move(pl);
+                out.append(std::move(np));
+            }
+        } else if (const ExtrusionEntityCollection *coll = dynamic_cast<const ExtrusionEntityCollection*>(ent)) {
+            ExtrusionEntityCollection clipped = clip_perimeters_outside_of(*coll, clip_region);
+            if (!clipped.empty())
+                out.append(std::move(clipped));
+        } else {
+            out.append(*ent);
+        }
+    }
+    return out;
+}
+
+void PerimeterGenerator::apply_extra_perimeters(ExPolygons &infill_area, const ExPolygon &island_region)
 {
     const bool use_wave_overhangs = this->config->wave_overhangs;
     const bool gate_extra_perims  = this->config->extra_perimeters_on_overhangs || use_wave_overhangs;
     if (!m_spiral_vase && this->lower_slices != nullptr && this->config->detect_overhang_wall && gate_extra_perims &&
         this->config->wall_loops > 0 && this->layer_id > this->object_config->raft_layers) {
-        // Generate extra perimeters on overhang areas, and cut them to these parts only, to save print time and material
+        // For wave overhangs, feed the full pre-perimeter island to the generator so the wave
+        // sees the complete overhang zone, not just the wall-shrunk leftover. This lets
+        // wave_overhang_outer_perimeters work independently of wall_loops. The legacy
+        // extra_perimeters_on_overhangs path still gets the post-perimeter infill_area since
+        // it's meant to add perimeters on top of existing ones.
+        ExPolygons wave_input_area;
+        if (use_wave_overhangs)
+            wave_input_area.emplace_back(island_region);
+
         auto [extra_perimeters, filled_area] = use_wave_overhangs
-            ? generate_wave_overhang_paths(infill_area, this->lower_slices_polygons(),
+            ? generate_wave_overhang_paths(wave_input_area, this->lower_slices_polygons(),
                                            this->config->wall_loops, *this->config,
                                            this->overhang_flow, this->m_scaled_resolution)
             : generate_extra_perimeters_over_overhangs(infill_area, this->lower_slices_polygons(),
@@ -1180,7 +1268,15 @@ void PerimeterGenerator::apply_extra_perimeters(ExPolygons &infill_area)
             for (const ExtrusionPaths &paths : extra_perimeters) {
                 new_perimeters.append(paths);
             }
-            new_perimeters.append(this_islands_perimeters->entities);
+            if (use_wave_overhangs) {
+                // Carve the existing wall_loops out of the wave-covered area so the overhang
+                // zone prints only the wave's own shells and pattern, not the Quality-tab
+                // perimeters running through it as extra rings.
+                ExtrusionEntityCollection clipped = clip_perimeters_outside_of(*this_islands_perimeters, filled_area);
+                new_perimeters.append(std::move(clipped.entities));
+            } else {
+                new_perimeters.append(this_islands_perimeters->entities);
+            }
             this_islands_perimeters->swap(new_perimeters);
 
             SurfaceCollection orig_surfaces = *this->fill_surfaces;
@@ -1772,7 +1868,7 @@ void PerimeterGenerator::process_classic()
         }
         this->fill_surfaces->append(infill_exp, stInternal);
 
-        apply_extra_perimeters(infill_exp);
+        apply_extra_perimeters(infill_exp, surface.expolygon);
 
         // BBS: get the no-overlap infill expolygons
         {
@@ -2629,7 +2725,7 @@ void PerimeterGenerator::process_arachne()
         }
         this->fill_surfaces->append(infill_exp, stInternal);
 
-        apply_extra_perimeters(infill_exp);
+        apply_extra_perimeters(infill_exp, surface.expolygon);
 
         // BBS: get the no-overlap infill expolygons
         {

--- a/src/libslic3r/PerimeterGenerator.cpp
+++ b/src/libslic3r/PerimeterGenerator.cpp
@@ -1226,7 +1226,7 @@ static ExtrusionEntityCollection clip_perimeters_outside_of(const ExtrusionEntit
     return out;
 }
 
-void PerimeterGenerator::apply_extra_perimeters(ExPolygons &infill_area)
+void PerimeterGenerator::apply_extra_perimeters(ExPolygons &infill_area, const ExPolygon &island_region)
 {
     const bool use_wave_overhangs = this->config->wave_overhangs;
     const bool gate_extra_perims  = this->config->extra_perimeters_on_overhangs || use_wave_overhangs;
@@ -1263,11 +1263,24 @@ void PerimeterGenerator::apply_extra_perimeters(ExPolygons &infill_area)
             for (const ExtrusionPaths &paths : extra_perimeters) {
                 new_perimeters.append(paths);
             }
-            if (use_wave_overhangs) {
-                // Carve the existing wall_loops out of the wave-covered area so the overhang
-                // zone prints only the wave's own shells and pattern, not the Quality-tab
-                // perimeters running through it as extra rings.
-                ExtrusionEntityCollection clipped = clip_perimeters_outside_of(*this_islands_perimeters, filled_area);
+            if (use_wave_overhangs && !filled_area.empty()) {
+                // Clip normal perimeters out of the island's overhang zone so only the wave's
+                // output lives there. We don't clip against filled_area directly because the
+                // wave's internal anchor shrink and the wall_loops shrink of infill_area
+                // leave filled_area smaller than the real overhang — the outer wall_loops
+                // rings would survive at the overhang edge. Instead, carve the full geometric
+                // overhang (island - lower_slices) and gate it by proximity to where the
+                // wave actually covered, so bridgeable overhangs that the wave chose to skip
+                // keep their perimeters intact.
+                Polygons island_polys = to_polygons(ExPolygons{island_region});
+                Polygons overhang_zone = diff(island_polys, this->lower_slices_polygons());
+                // Generous reach from the wave's footprint so we catch the full overhang
+                // band the wave was meant to service. EXTERNAL_INFILL_MARGIN matches the
+                // anchor-size ceiling in the wave generator.
+                const coord_t reach = coord_t(scale_(EXTERNAL_INFILL_MARGIN));
+                Polygons clip_region = intersection(expand(filled_area, reach, jtRound, 0.),
+                                                    overhang_zone);
+                ExtrusionEntityCollection clipped = clip_perimeters_outside_of(*this_islands_perimeters, clip_region);
                 new_perimeters.append(std::move(clipped.entities));
             } else {
                 new_perimeters.append(this_islands_perimeters->entities);
@@ -1863,7 +1876,7 @@ void PerimeterGenerator::process_classic()
         }
         this->fill_surfaces->append(infill_exp, stInternal);
 
-        apply_extra_perimeters(infill_exp);
+        apply_extra_perimeters(infill_exp, surface.expolygon);
 
         // BBS: get the no-overlap infill expolygons
         {
@@ -2720,7 +2733,7 @@ void PerimeterGenerator::process_arachne()
         }
         this->fill_surfaces->append(infill_exp, stInternal);
 
-        apply_extra_perimeters(infill_exp);
+        apply_extra_perimeters(infill_exp, surface.expolygon);
 
         // BBS: get the no-overlap infill expolygons
         {

--- a/src/libslic3r/PerimeterGenerator.hpp
+++ b/src/libslic3r/PerimeterGenerator.hpp
@@ -152,7 +152,7 @@ public:
 private:
     std::vector<Polygons>     generate_lower_polygons_series(float width);
     void split_top_surfaces(const ExPolygons &orig_polygons, ExPolygons &top_fills, ExPolygons &non_top_polygons, ExPolygons &fill_clip) const;
-    void apply_extra_perimeters(ExPolygons& infill_area, const ExPolygon& island_region);
+    void apply_extra_perimeters(ExPolygons& infill_area);
     void process_no_bridge(Surfaces& all_surfaces, coord_t perimeter_spacing, coord_t ext_perimeter_width);
 
 private:

--- a/src/libslic3r/PerimeterGenerator.hpp
+++ b/src/libslic3r/PerimeterGenerator.hpp
@@ -152,7 +152,7 @@ public:
 private:
     std::vector<Polygons>     generate_lower_polygons_series(float width);
     void split_top_surfaces(const ExPolygons &orig_polygons, ExPolygons &top_fills, ExPolygons &non_top_polygons, ExPolygons &fill_clip) const;
-    void apply_extra_perimeters(ExPolygons& infill_area);
+    void apply_extra_perimeters(ExPolygons& infill_area, const ExPolygon& island_region);
     void process_no_bridge(Surfaces& all_surfaces, coord_t perimeter_spacing, coord_t ext_perimeter_width);
 
 private:

--- a/src/libslic3r/PrintConfig.cpp
+++ b/src/libslic3r/PrintConfig.cpp
@@ -4625,8 +4625,12 @@ void PrintConfigDef::init_fff_params()
     def = this->add("wave_overhang_outer_perimeters", coInt);
     def->label = L("Perimeters");
     def->category = L("Strength");
-    def->tooltip = L("Number of additional concentric outer-shell perimeters printed inside the "
-                     "overhang region before the wave fill. 1 is usually enough.");
+    def->tooltip = L("Number of outer perimeters preserved inside the overhang region. The rest of the "
+                     "overhang is replaced by the wave pattern. Independent of Quality › Walls: "
+                     "setting this to 1 always gives one outer wall then wave, regardless of how many "
+                     "walls the rest of the object uses. 1 is usually enough. Set to 0 for pure wave "
+                     "(no perimeter at the overhang boundary). Capped at the effective wall count for "
+                     "the layer (e.g. 1 on topmost layers with \"only one wall top\").");
     def->mode = comAdvanced;
     def->min = 0;
     def->set_default_value(new ConfigOptionInt(1));


### PR DESCRIPTION
## Summary

Makes `wave_overhang_outer_perimeters` independent of the Quality-tab `wall_loops` so the overhang zone prints exactly the wave's own shells + pattern, not the object's normal walls running through it.

## Reporter symptoms

- Wave overhangs showed the same number of walls as Quality > Walls (Kobra S1, Ender 3).
- Bumping `wall_loops` made the wave layer go weird and triggered full-area support generation even though the wave should have covered the overhang.

## Root cause

Three coupled issues:

1. **Perimeter-count cap.** `desired_wave_perimeters = min(wave_overhang_outer_perimeters, wall_loops)` at `PerimeterGenerator.cpp:1098` silently clamped the wave setting to the Quality-tab value.
2. **Wall-shrunk input.** The wave generator received `infill_area` after `wall_loops` normal perimeters had already eaten inward, so with high wall_loops it saw only a thin crumb of the overhang. Wave coverage shrank accordingly.
3. **No carve-out.** Normal `wall_loops` perimeters ran through the overhang zone unchanged. They were simply *prepended to* by wave paths, not replaced.

Symptom (2) also explains the support-generation complaint: `out_wave_overhang_covered_polygons` is stashed from `filled_area`, so when wave coverage shrank, the support pipeline saw most of the overhang as uncovered and kicked in full support.

## Changes

- `PerimeterGenerator.cpp:1098` — drop the `min(..., wall_loops)` cap. Honor `wave_overhang_outer_perimeters` directly (floored at 0).
- `PerimeterGenerator.cpp:1229` — pass the island's pre-perimeter `surface.expolygon` to the wave generator instead of the wall-shrunk leftover, so the wave sees the full overhang.
- New helper `clip_perimeters_outside_of()` — trims existing `ExtrusionLoop` / `ExtrusionMultiPath` / `ExtrusionPath` entities in the region's perimeter collection against the wave's `filled_area`. Bbox-disjoint entities are preserved as-is; cut loops become `ExtrusionMultiPath` with per-path role / width / height / mm³-per-mm intact.
- `PerimeterGenerator.hpp` — `apply_extra_perimeters` takes the island ExPolygon. Both call sites (classic + arachne) pass `surface.expolygon`.

The legacy `extra_perimeters_on_overhangs` path is unchanged — still receives `infill_area` and doesn't carve, since its semantics are "add extra perimeters on top."

## Test plan

- [ ] Build succeeds on Linux / macOS / Windows (CI).
- [ ] Slice wavebench with `wave_overhangs=on`, `wave_overhang_outer_perimeters=1`, and sweep `wall_loops` across 1-6. Preview should show exactly 1 wave shell in the overhang regardless of `wall_loops`.
- [ ] Same sweep with supports enabled: support generation should no longer spread to the full overhang area as `wall_loops` increases.
- [ ] Existing regression: `extra_perimeters_on_overhangs=on, wave_overhangs=off` path should be byte-identical to before.
- [ ] Classic perimeter generator and Arachne both exercised (toggle via `wall_generator` setting).