### PR TITLE
fix(wave-overhangs): guard clip_paths against degenerate polylines

### DIFF
--- a/src/libslic3r/PerimeterGenerator.cpp
+++ b/src/libslic3r/PerimeterGenerator.cpp
@@ -1183,10 +1183,21 @@ static ExtrusionEntityCollection clip_inner_perimeters_in_zone(const ExtrusionEn
             // Shortening the centerline by half a width pulls those caps back so they end
             // right at the clip boundary, matching the wave's extrusion edge cleanly.
             const double half_w = scale_(double(p.width) * 0.5);
+            // Polylines shorter than 2 * half_w would be drained past empty by the
+            // chained clip_start + clip_end below: Polyline::clip_end pop_backs without
+            // re-checking emptiness on every iteration and underflows its remove_after_index
+            // counter (size_t), which surfaces non-deterministically as bad_alloc or
+            // length_error in a sibling allocation under TBB. Skip those polylines and
+            // re-check size between the two clip calls.
+            const double cap_drain_length = 2.0 * half_w + double(SCALED_EPSILON);
             for (Polyline &pl : kept) {
                 if (pl.points.size() < 2)
                     continue;
+                if (half_w > 0. && pl.length() <= cap_drain_length)
+                    continue;
                 pl.clip_start(half_w);
+                if (pl.points.size() < 2)
+                    continue;
                 pl.clip_end(half_w);
                 if (pl.points.size() < 2)
                     continue;


### PR DESCRIPTION
## Summary

- Guards the `clip_paths` lambda in `clip_inner_perimeters_in_zone` (PR #31) against polylines whose total length is at most the combined cap retraction. Fixes "vector too long" / `std::bad_alloc` on slice on v0.2.3, reported at https://waveoverhangs.com/gallery/72.
- Re-checks polyline size between `clip_start` and `clip_end` so a polyline drained by the first call can't be fed into the second.
- Branched from v0.2.3, no other changes. Intended to ship as v0.2.4.

## Root cause

`Polyline::clip_end` `pop_back`s without re-checking emptiness on every iteration and underflows its internal `size_t remove_after_index` counter on degenerate inputs. The chained `clip_start` then `clip_end` trims in PR #31's `clip_paths` lambda can drive a short polyline past empty and trigger that path. Under TBB it surfaces non-deterministically as `bad_alloc` or `length_error` in a sibling allocation. Reproduced deterministically on the v0.2.3 Linux AppImage with the reporter's 3MF; gdb backtrace pinned the throw to the lambda (`clip_inner_perimeters_in_zone(...)::$_1::operator()(...)`).

## Why master "works"

PR #29 (corner-taper, still open) adds inert default-off code paths in `WaveOverhangs::generate` and surrounding helpers. Those additions shift codegen enough to hide this UB under one binary layout. The bug was latent on that branch, not actually fixed. v0.2.3 just got unlucky on layout.

## Test plan

- [ ] Build locally from this branch.
- [ ] Slice the reporter's 3MF on the patched binary; expected: clean slice, no throw.
- [ ] Slice a known-good model with wave overhangs enabled; expected: identical output as v0.2.3 (the new guard only short-circuits on degenerate input that would have crashed anyway).
- [ ] AppImage release workflow run on the v0.2.4 tag; expected: green.