### PR TITLE
feat(wave-overhangs): GUI restructure + corner-taper master toggle

### DIFF
--- a/src/libslic3r/GCode.cpp
+++ b/src/libslic3r/GCode.cpp
@@ -2555,7 +2555,7 @@ void GCode::_do_export(Print& print, GCodeOutputStream &file, ThumbnailsGenerato
                         " pattern=%s spacing_mode=%s seam_mode=%s"
                         " perimeter_overlap=%.2f minimum_wave_width=%.2f"
                         " min_new_area=%.4f"
-                        " corner_spacing=%.3f corner_taper=%.2f corner_angle=%.0f"
+                        " corner_enable=%d corner_spacing=%.3f corner_taper=%.2f corner_angle=%.0f"
                         " end_retract=%.2f"
                         " nozzle_temp_override=%d min_wave_time=%.2f min_layer_time=%.2f"
                         " wall_loops=%d top_shell_layers=%d bottom_shell_layers=%d"
@@ -2577,6 +2577,7 @@ void GCode::_do_export(Print& print, GCodeOutputStream &file, ThumbnailsGenerato
                         rc.wave_overhang_perimeter_overlap.value,
                         rc.wave_overhang_minimum_width.value,
                         rc.wave_overhang_min_new_area.value,
+                        rc.wave_overhang_corner_taper_enable.value ? 1 : 0,
                         rc.wave_overhang_line_spacing_corner.value,
                         rc.wave_overhang_corner_taper_distance.value,
                         rc.wave_overhang_corner_angle_threshold.value,

--- a/src/libslic3r/PerimeterGenerator.cpp
+++ b/src/libslic3r/PerimeterGenerator.cpp
@@ -1121,6 +1121,7 @@ static std::tuple<std::vector<ExtrusionPaths>, Polygons> generate_wave_overhang_
     params.pattern              = region_config.wave_overhang_pattern.value;
     params.min_new_area         = region_config.wave_overhang_min_new_area.value;
     params.use_instead_of_bridges = region_config.wave_overhangs_instead_of_bridges.value;
+    params.corner_taper_enable    = region_config.wave_overhang_corner_taper_enable.value;
     params.line_spacing_corner    = region_config.wave_overhang_line_spacing_corner.value;
     params.corner_taper_distance  = region_config.wave_overhang_corner_taper_distance.value;
     params.corner_angle_threshold = region_config.wave_overhang_corner_angle_threshold.value;

--- a/src/libslic3r/Preset.cpp
+++ b/src/libslic3r/Preset.cpp
@@ -906,6 +906,8 @@ static std::vector<std::string> s_Preset_print_options {
     "wave_overhang_spacing_mode", "wave_overhang_seam_mode",
     "wave_overhang_debug_gcode", "wave_overhang_min_length",
     "wave_overhang_max_iterations", "wave_overhang_min_new_area", "wave_overhang_end_retract_length",
+    "wave_overhang_corner_taper_enable", "wave_overhang_line_spacing_corner",
+    "wave_overhang_corner_taper_distance", "wave_overhang_corner_angle_threshold",
     "seam_position", "staggered_inner_seams", "wall_sequence", "is_infill_first", "sparse_infill_density","fill_multiline", "sparse_infill_pattern", "lateral_lattice_angle_1", "lateral_lattice_angle_2", "infill_overhang_angle", "top_surface_pattern", "bottom_surface_pattern",
     "infill_direction", "solid_infill_direction", "counterbore_hole_bridging","infill_shift_step", "sparse_infill_rotate_template", "solid_infill_rotate_template", "symmetric_infill_y_axis","skeleton_infill_density", "infill_lock_depth", "skin_infill_depth", "skin_infill_density",
     "align_infill_direction_to_model", "extra_solid_infills",

--- a/src/libslic3r/PrintConfig.cpp
+++ b/src/libslic3r/PrintConfig.cpp
@@ -4766,14 +4766,27 @@ void PrintConfigDef::init_fff_params()
     def->max = 300;
     def->set_default_value(new ConfigOptionFloat(0.0));
 
+    def = this->add("wave_overhang_corner_taper_enable", coBool);
+    def->label = L("Enable corner-aware spacing taper");
+    def->category = L("Quality");
+    def->tooltip = L("When enabled, the wave-overhang generator densifies line spacing near sharp "
+                     "convex corners of the overhang outline. Corners warp worst because their "
+                     "cantilevered wave lines are short and have little neighbouring material to "
+                     "fuse with, so they curl as PLA cools. Packing more lines into a small radius "
+                     "around each corner gives each short line a neighbour to bond with, resisting "
+                     "the curl. Andersons-only; the corner radius, denser spacing, and angle "
+                     "threshold appear when this is on.");
+    def->mode = comAdvanced;
+    def->set_default_value(new ConfigOptionBool(false));
+
     def = this->add("wave_overhang_line_spacing_corner", coFloat);
     def->label = L("Corner line spacing");
     def->category = L("Quality");
     def->tooltip = L("Denser line spacing used near detected sharp corners of the overhang region. "
                      "Corners warp worst because short cantilevered wave lines cool unevenly and curl. "
                      "Packing more lines into the corner zone gives each line a nearby neighbour to "
-                     "fuse with, resisting the curl. Set equal to the main line spacing (or 0) to "
-                     "disable corner-aware tapering.");
+                     "fuse with, resisting the curl. Must be smaller than the main line spacing for "
+                     "the taper to engage; the master toggle above must also be on.");
     def->sidetext = L("mm");
     def->mode = comAdvanced;
     def->min = 0;

--- a/src/libslic3r/PrintConfig.hpp
+++ b/src/libslic3r/PrintConfig.hpp
@@ -1173,6 +1173,7 @@ PRINT_CONFIG_CLASS_DEFINE(
     ((ConfigOptionFloat,                     wave_overhang_min_length))
     ((ConfigOptionInt,                       wave_overhang_max_iterations))
     ((ConfigOptionFloat,                     wave_overhang_min_new_area))
+    ((ConfigOptionBool,                      wave_overhang_corner_taper_enable))
     ((ConfigOptionFloat,                     wave_overhang_line_spacing_corner))
     ((ConfigOptionFloat,                     wave_overhang_corner_taper_distance))
     ((ConfigOptionFloat,                     wave_overhang_corner_angle_threshold))

--- a/src/libslic3r/WaveOverhangs/AndersonsGenerator.cpp
+++ b/src/libslic3r/WaveOverhangs/AndersonsGenerator.cpp
@@ -41,6 +41,7 @@ GenerateResult AndersonsGenerator::generate(const ExPolygons   &overhang_area,
         params.max_iterations,
         params.min_new_area,
         params.use_instead_of_bridges,
+        params.corner_taper_enable,
         params.line_spacing_corner,
         params.corner_taper_distance,
         params.corner_angle_threshold);

--- a/src/libslic3r/WaveOverhangs/IGenerator.hpp
+++ b/src/libslic3r/WaveOverhangs/IGenerator.hpp
@@ -40,8 +40,13 @@ struct CommonParams {
     double      min_new_area           = 0.01;  // mm^2; early-termination threshold on new-area growth.
     bool        use_instead_of_bridges = false; // when true, wave over flat bridgeable spans too.
     // Corner-aware spacing taper: densify line spacing near sharp overhang corners
-    // so short cantilevered wave lines have neighbours to fuse with. When taper is
-    // disabled (defaults), the main propagation is untouched.
+    // so short cantilevered wave lines have neighbours to fuse with. The master
+    // gate is `corner_taper_enable`; when false the main propagation runs
+    // verbatim regardless of the other three values. The downstream generator
+    // ALSO refuses to engage when line_spacing_corner is 0 or >= line_spacing,
+    // or when corner_taper_distance is 0, so a partially-configured taper is
+    // a no-op rather than a silent surprise.
+    bool        corner_taper_enable    = false;
     double      line_spacing_corner    = 0.0;   // mm; 0 or >= line_spacing means taper off.
     double      corner_taper_distance  = 0.0;   // mm; radius of corner influence. 0 = taper off.
     double      corner_angle_threshold = 90.0;  // degrees; interior angle below this is a corner.

--- a/src/libslic3r/WaveOverhangs/WaveOverhangs.cpp
+++ b/src/libslic3r/WaveOverhangs/WaveOverhangs.cpp
@@ -699,6 +699,7 @@ std::tuple<std::vector<ExtrusionPaths>, Polygons> generate(
     int             max_iterations,
     double          min_new_area_mm2,
     bool            use_instead_of_bridges,
+    bool            corner_taper_enable,
     double          line_spacing_corner_mm,
     double          corner_taper_distance_mm,
     double          corner_angle_threshold_deg)
@@ -709,18 +710,23 @@ std::tuple<std::vector<ExtrusionPaths>, Polygons> generate(
     const coord_t wave_spacing       = std::max<coord_t>(1, wave_line_spacing > 0. ? coord_t(scale_(wave_line_spacing)) : base_spacing);
     const coord_t min_wave_width     = std::max<coord_t>(0, minimum_wave_width > 0. ? coord_t(scale_(minimum_wave_width)) : 0);
 
-    // Corner-aware spacing taper parameters. Taper is off when the user leaves
-    // line_spacing_corner at 0, sets it >= the main spacing, or leaves the
-    // taper distance at 0. In the disabled state the main loop below runs
-    // unchanged — critical for backwards compatibility with existing profiles.
-    const coord_t wave_spacing_corner = (line_spacing_corner_mm > 0.
+    // Corner-aware spacing taper parameters. The master gate is the user-facing
+    // toggle: when corner_taper_enable is false the rest is ignored and the
+    // main loop runs unchanged (matches v0.2.x behaviour). When enabled, the
+    // taper still self-disables if the values don't make sense — corner
+    // spacing must be smaller than main spacing AND the taper distance must
+    // be > 0, otherwise there is nothing to densify.
+    const coord_t wave_spacing_corner = (corner_taper_enable
+                                         && line_spacing_corner_mm > 0.
                                          && line_spacing_corner_mm < wave_line_spacing)
                                         ? std::max<coord_t>(1, coord_t(scale_(line_spacing_corner_mm)))
                                         : wave_spacing;
-    const coord_t corner_taper_dist   = (corner_taper_distance_mm > 0.)
+    const coord_t corner_taper_dist   = (corner_taper_enable && corner_taper_distance_mm > 0.)
                                         ? coord_t(scale_(corner_taper_distance_mm))
                                         : 0;
-    const bool    taper_enabled       = wave_spacing_corner < wave_spacing && corner_taper_dist > 0;
+    const bool    taper_enabled       = corner_taper_enable
+                                        && wave_spacing_corner < wave_spacing
+                                        && corner_taper_dist > 0;
     // Sub-steps between main wavefronts. Example: main 0.35 mm, corner 0.175 mm
     // → 2 sub-steps (one intercalated front between each pair of main fronts).
     // Capped at 8 to guard against a pathological corner spacing near zero.

--- a/src/libslic3r/WaveOverhangs/WaveOverhangs.hpp
+++ b/src/libslic3r/WaveOverhangs/WaveOverhangs.hpp
@@ -36,8 +36,11 @@ std::tuple<std::vector<ExtrusionPaths>, Polygons> generate(
     int             max_iterations            = 0,
     double          min_new_area_mm2          = 0.01,
     bool            use_instead_of_bridges    = false,
-    // Corner-aware spacing taper. Disabled when corner_taper_distance_mm <= 0 or
-    // line_spacing_corner_mm is not smaller than wave_line_spacing.
+    // Corner-aware spacing taper. Master gate: corner_taper_enable=false skips
+    // the taper entirely regardless of the other three values. When enabled
+    // it also requires line_spacing_corner_mm < wave_line_spacing AND
+    // corner_taper_distance_mm > 0 to actually emit denser corner fronts.
+    bool            corner_taper_enable        = false,
     double          line_spacing_corner_mm    = 0.0,
     double          corner_taper_distance_mm  = 0.0,
     double          corner_angle_threshold_deg = 90.0);

--- a/src/slic3r/GUI/ConfigManipulation.cpp
+++ b/src/slic3r/GUI/ConfigManipulation.cpp
@@ -1005,8 +1005,21 @@ void ConfigManipulation::toggle_print_fff_options(DynamicPrintConfig *config, co
         std::string("wave_overhang_line_spacing"),
         std::string("wave_overhang_spacing_mode"),
         std::string("wave_overhang_min_new_area"),
+        std::string("wave_overhang_corner_taper_enable"),
     })
         toggle_line(k, wo_enabled && is_andersons);
+
+    // Orca: corner-reinforcement sub-options. Master toggle reveals the three
+    // tunables — same shape as the Hilbert-floor section below. Sub-options
+    // are gated on master toggle + Andersons (Kaiser doesn't honour them).
+    const bool wo_corner_taper = wo_enabled && is_andersons
+        && config->opt_bool("wave_overhang_corner_taper_enable");
+    for (const std::string &k : {
+        std::string("wave_overhang_line_spacing_corner"),
+        std::string("wave_overhang_corner_taper_distance"),
+        std::string("wave_overhang_corner_angle_threshold"),
+    })
+        toggle_line(k, wo_corner_taper);
 
     // Orca: wave-overhang Hilbert floor sub-options. Only meaningful when the
     // master Hilbert toggle is on AND wave overhangs themselves are enabled.

--- a/src/slic3r/GUI/Tab.cpp
+++ b/src/slic3r/GUI/Tab.cpp
@@ -2402,39 +2402,56 @@ void TabPrint::build()
         optgroup->append_single_option_line("overhang_reverse_internal_only", "quality_settings_overhangs#reverse-internal-only");
         optgroup->append_single_option_line("overhang_reverse_threshold", "quality_settings_overhangs#reverse-threshold");
 
-    // Dedicated Wave Overhangs page — all wave-overhang options grouped here
-    // (master toggle, algorithm, geometry, motion, cooling, top layers, debug).
+    // Dedicated Wave Overhangs page. Layout follows the user's mental model
+    // top-to-bottom: "do I want this?" (General) -> "which overhangs qualify?"
+    // (Detection) -> "what does the wave look like?" (Pattern) -> "extra lever
+    // for sharp corners?" (Corner reinforcement, opt-in) -> "how does it print?"
+    // (Motion + Cooling) -> "what sits on top?" (Floor layers) -> debug. The
+    // two opt-in sub-features (Corner reinforcement here, Hilbert under Floor
+    // layers) both follow a master-toggle + reveal-sub-options pattern so
+    // they're structurally consistent.
     page = add_options_page(L("Wave overhangs"), "custom-gcode_quality");
         optgroup = page->new_optgroup(L("General"), L"param_overhang");
         optgroup->append_single_option_line("wave_overhangs");
         optgroup->append_single_option_line("wave_overhangs_instead_of_bridges");
         optgroup->append_single_option_line("wave_overhang_algorithm");
+        optgroup->append_single_option_line("support_remaining_areas_after_wave_overhangs");
+
+        optgroup = page->new_optgroup(L("Detection"), L"param_overhang");
         optgroup->append_single_option_line("wave_overhang_min_angle");
         optgroup->append_single_option_line("wave_overhang_min_length");
         optgroup->append_single_option_line("wave_overhang_max_iterations");
 
-        optgroup = page->new_optgroup(L("Geometry"), L"param_overhang");
-        optgroup->append_single_option_line("wave_overhang_outer_perimeters");
-        optgroup->append_single_option_line("wave_overhang_seam_mode");
-
-        // Algorithm tuning: rows here are filtered by the active algorithm
-        // (ConfigManipulation::toggle_line). Kaiser sees only ring_overlap;
-        // Andersons sees the wavefront-propagation knobs. Mixed in one section
-        // so empty-algorithm sections don't render as blank headers.
-        optgroup = page->new_optgroup(L("Algorithm tuning"), L"param_overhang");
-        optgroup->append_single_option_line("wave_overhang_flow_mm3_per_mm");
-        optgroup->append_single_option_line("wave_overhang_end_retract_length");
-        optgroup->append_single_option_line("wave_overhang_ring_overlap");
+        // Pattern: how the wave is shaped. Algo-specific rows are filtered by
+        // ConfigManipulation::toggle_line — Andersons sees most of these,
+        // Kaiser only sees ring_overlap. They share the section header so an
+        // algo switch doesn't leave an empty section behind.
+        optgroup = page->new_optgroup(L("Pattern"), L"param_overhang");
         optgroup->append_single_option_line("wave_overhang_pattern");
-        optgroup->append_single_option_line("wave_overhang_perimeter_overlap");
-        optgroup->append_single_option_line("wave_overhang_minimum_width");
+        optgroup->append_single_option_line("wave_overhang_seam_mode");
+        optgroup->append_single_option_line("wave_overhang_outer_perimeters");
         optgroup->append_single_option_line("wave_overhang_line_spacing");
         optgroup->append_single_option_line("wave_overhang_spacing_mode");
+        optgroup->append_single_option_line("wave_overhang_perimeter_overlap");
+        optgroup->append_single_option_line("wave_overhang_minimum_width");
         optgroup->append_single_option_line("wave_overhang_min_new_area");
+        optgroup->append_single_option_line("wave_overhang_flow_mm3_per_mm");
+        optgroup->append_single_option_line("wave_overhang_ring_overlap"); // Kaiser-only
 
-        optgroup = page->new_optgroup(L("Speed"), L"param_speed");
+        // Corner reinforcement: opt-in feature. Master toggle reveals the
+        // three tunables (matches the pattern used by Hilbert under Floor
+        // layers). Andersons-only — ConfigManipulation gates the sub-options
+        // on algo + master toggle so the sub-rows hide cleanly when off.
+        optgroup = page->new_optgroup(L("Corner reinforcement"), L"param_overhang");
+        optgroup->append_single_option_line("wave_overhang_corner_taper_enable");
+        optgroup->append_single_option_line("wave_overhang_line_spacing_corner");
+        optgroup->append_single_option_line("wave_overhang_corner_taper_distance");
+        optgroup->append_single_option_line("wave_overhang_corner_angle_threshold");
+
+        optgroup = page->new_optgroup(L("Motion"), L"param_speed");
         optgroup->append_single_option_line("wave_overhang_print_speed");
         optgroup->append_single_option_line("wave_overhang_travel_speed");
+        optgroup->append_single_option_line("wave_overhang_end_retract_length");
 
         optgroup = page->new_optgroup(L("Cooling"), L"param_cooling");
         optgroup->append_single_option_line("wave_overhang_fan_speed");
@@ -2449,9 +2466,6 @@ void TabPrint::build()
         optgroup->append_single_option_line("wave_overhang_floor_hilbert_density");
         optgroup->append_single_option_line("wave_overhang_floor_print_speed");
         optgroup->append_single_option_line("wave_overhang_floor_fan_speed");
-
-        optgroup = page->new_optgroup(L("Support integration"), L"param_overhang");
-        optgroup->append_single_option_line("support_remaining_areas_after_wave_overhangs");
 
         optgroup = page->new_optgroup(L("Debug"), L"param_overhang");
         optgroup->append_single_option_line("wave_overhang_debug_gcode");


### PR DESCRIPTION
## Summary

Two paired changes to the Wave Overhangs print-settings page:

### 1. Corner-taper master toggle (`wave_overhang_corner_taper_enable`)

New \`ConfigOptionBool\`, default false. Becomes the user-facing on/off for the corner-aware spacing taper (PR #29), mirroring how \`wave_overhang_floor_use_hilbert\` gates the Hilbert sub-options. Activation now requires the bool true **AND** the existing per-value gates (\`line_spacing_corner < line_spacing\`, \`taper_distance > 0\`) - inert profiles stay inert, no silent activation.

### 2. Wave Overhangs page reorganised

| Old | New |
| --- | --- |
| General (master + algo + detection thresholds mixed) | **General** (master + scope + algorithm + support handoff) |
| Geometry (2 fields: outer_perim + seam_mode) | merged into Pattern |
| Algorithm tuning (12 fields, mixed Andersons + Kaiser + universal) | split into Pattern + Corner reinforcement; end_retract moved to Motion; flow & seam_mode moved to Pattern |
| Speed (2 fields) | merged into **Motion** |
| Cooling | unchanged |
| Floor layers | unchanged (already master-toggle pattern) |
| Support integration (1 field) | folded into General |
| - | **Detection** (min_angle, min_length, max_iterations) |
| - | **Corner reinforcement** (master + 3 sub-options) |
| Debug | unchanged |

Net: 9 sections -> 8, each with one coherent concept. The two opt-in features (Corner reinforcement, Hilbert under Floor layers) now follow the same master-toggle + reveal-sub-options pattern.

## Files
- \`PrintConfig.{hpp,cpp}\` + \`Preset.cpp\` register the new key
- \`WaveOverhangs/{IGenerator,WaveOverhangs,AndersonsGenerator}.{hpp,cpp}\` + \`PerimeterGenerator.cpp\` pipe the bool through to the activation gate
- \`Tab.cpp\` restructures the page
- \`ConfigManipulation.cpp\` gates the corner-taper sub-options on master + Andersons
- \`GCode.cpp\` emits \`corner_enable=%d\` in the \`WAVE_OVERHANG_CONFIG\` header so waveoverhangs.com can show whether the feature was actually engaged

## Test plan
- [ ] Open Wave Overhangs page on a fresh install -> 8 sections, ordering matches the table above
- [ ] Toggle \`wave_overhang_corner_taper_enable\` off -> 3 sub-options hide
- [ ] Toggle on -> 3 sub-options appear; switch algorithm to Kaiser -> whole Corner reinforcement section greys out
- [ ] With master toggle off, set the 3 corner values to non-zero -> taper does NOT engage in the slice (verify via G-code preview, no extra \`; WAVE_OVERHANG_START\` blocks at corners)
- [ ] With master toggle on + sane values -> taper engages as before (extra blocks at corners)
- [ ] G-code header includes \`corner_enable=0\` or \`corner_enable=1\` per the toggle state