### PR TITLE
Fix Ender-3 V3 KE nozzle switching

### DIFF
--- a/resources/profiles/Creality.json
+++ b/resources/profiles/Creality.json
@@ -1,6 +1,6 @@
 {
     "name": "Creality",
-    "version": "02.03.02.61",
+    "version": "02.03.02.62",
     "force_update": "0",
     "description": "Creality configurations",
     "machine_model_list": [

--- a/resources/profiles/Creality/machine/Creality Ender-3 V3 KE 0.2 nozzle.json
+++ b/resources/profiles/Creality/machine/Creality Ender-3 V3 KE 0.2 nozzle.json
@@ -5,6 +5,7 @@
     "from": "system",
     "setting_id": "GM001",
     "instantiation": "true",
+    "printer_variant": "0.2",
     "printer_settings_id": "Creality",
     "printer_model": "Creality Ender-3 V3 KE",
     "gcode_flavor": "klipper",

--- a/resources/profiles/Creality/machine/Creality Ender-3 V3 KE 0.4 nozzle.json
+++ b/resources/profiles/Creality/machine/Creality Ender-3 V3 KE 0.4 nozzle.json
@@ -5,6 +5,7 @@
     "from": "system",
     "setting_id": "GM001",
     "instantiation": "true",
+    "printer_variant": "0.4",
     "printer_settings_id": "Creality",
     "printer_model": "Creality Ender-3 V3 KE",
     "gcode_flavor": "klipper",

--- a/resources/profiles/Creality/machine/Creality Ender-3 V3 KE 0.6 nozzle.json
+++ b/resources/profiles/Creality/machine/Creality Ender-3 V3 KE 0.6 nozzle.json
@@ -5,6 +5,7 @@
     "from": "system",
     "setting_id": "GM001",
     "instantiation": "true",
+    "printer_variant": "0.6",
     "printer_settings_id": "Creality",
     "printer_model": "Creality Ender-3 V3 KE",
     "gcode_flavor": "klipper",

--- a/resources/profiles/Creality/machine/Creality Ender-3 V3 KE 0.8 nozzle.json
+++ b/resources/profiles/Creality/machine/Creality Ender-3 V3 KE 0.8 nozzle.json
@@ -5,6 +5,7 @@
     "from": "system",
     "setting_id": "GM001",
     "instantiation": "true",
+    "printer_variant": "0.8",
     "printer_settings_id": "Creality",
     "printer_model": "Creality Ender-3 V3 KE",
     "gcode_flavor": "klipper",


### PR DESCRIPTION
Adds the missing `printer_variant` key (0.2/0.4/0.6/0.8) to the four Creality Ender-3 V3 KE nozzle profiles. Without it, OrcaSlicer cannot map a UI nozzle selection to a profile and reverts every choice to 0.2mm.

Pattern matches the existing CR-10 SE / K1C profiles. `setting_id` left as GM001 (shared family ID, also matches CR-10 SE / K1C).

Bumps Creality vendor version 02.03.02.61 -> 02.03.02.62.

Fixes #42