### PR TITLE
chore: slim issue templates, brand for WaveOverhangs

### DIFF
--- a/.github/ISSUE_TEMPLATE/bug_report.yml
+++ b/.github/ISSUE_TEMPLATE/bug_report.yml
@@ -1,133 +1,54 @@
-name: 🐞 Bug Report
-description: File a bug report
+name: Bug Report
+description: Something is broken in OrcaSlicer-WaveOverhangs (not specific to wave overhangs)
 labels: ["bug"]
 body:
   - type: markdown
     attributes:
       value: |
-        **Thank you for using Orca Slicer and wanting to report a bug.**
-        
-        Please note that this is not the place to make feature requests or ask for help.
-        For this, please use the [Feature request](https://github.com/OrcaSlicer/OrcaSlicer/issues/new?assignees=&labels=&projects=&template=feature_request.yml) issue type or you can discuss your idea on our [Discord server](https://discord.gg/P4VE9UY9gJ) with others.
-        
-        Before filing, please check if the issue already exists (either open or closed) by using the search bar on the issues page. If it does, comment there. Even if it's closed, we can reopen it based on your comment.
-  - type: checkboxes
-    attributes:
-      label: Is there an existing issue for this problem?
-      description: Please search to see if an issue already exists for the bug you encountered.
-      options:
-        - label: I have searched the existing issues
-          required: true
+        For bugs in wave-overhang slicing/printing specifically, use the [Wave Overhang Bug](https://github.com/dennisklappe/OrcaSlicer-WaveOverhangs/issues/new?template=wave_overhang_bug.yml) template instead, it asks for the debug headers.
+
   - type: input
     id: version
     attributes:
-      label: OrcaSlicer Version
-      description: Which version of Orca Slicer are you running? You can see the full version in `Help` -> `About Orca Slicer`.
-      placeholder: e.g. 1.9.0
+      label: Version
+      description: From `Help` → `About OrcaSlicer-WaveOverhangs`.
+      placeholder: "v0.3.1"
     validations:
       required: true
+
   - type: dropdown
-    id: os_type
+    id: os
     attributes:
-      label: "Operating System (OS)"
-      description: "What OSes are you are experiencing issues on?"
-      multiple: true
+      label: OS
       options:
-        - Linux
-        - macOS
         - Windows
+        - macOS
+        - Linux
     validations:
       required: true
-  - type: input
-    id: os_version
-    attributes:
-      label: "OS Version"
-      description: "What OS version does this relate to?"
-      placeholder: "i.e. OS: Windows 7/8/10/11 ..., Ubuntu 22.04/Fedora 36 ..., macOS 10.15/11.1/12.3 ..."
-    validations:
-      required: true
-  - type: textarea
-    id: system_info
-    attributes:
-      label: Additional system information
-      description: For the performance issue, please also show the CPU, Memory information; For the 3D Rendering issue, please also show the Display Card information.
-      placeholder: |
-        CPU: 11th gen Intel r core tm i7-1185g7/AMD Ryzen 7 6800h/...
-        Memory: 32/16 GB...
-        Display Card: NVIDIA Quadro P400/...
-    validations:
-      required: false
+
   - type: input
     id: printer
     attributes:
       label: Printer
-      description: Which printer was selected
-      placeholder: Voron 2.4/VzBot/Prusa MK4/Bambu Lab X1 series/Bambu Lab P1P/...
+      placeholder: "Bambu Lab A1, Voron 2.4, Prusa MK4, ..."
     validations:
-      required: true
-  - type: textarea
-    id: reproduce_steps
-    attributes:
-      label: How to reproduce
-      description: Please described the detailed steps to reproduce this issue
-      placeholder: |
-        1. Go to '...'
-        2. Click on '...'
-        3. Scroll down to '...'
-        4. See error
-    validations:
-      required: true
-  - type: textarea
-    id: actual_results
-    attributes:
-      label: Actual results
-      description: What happens after the above steps? Please, enclose a screenshot whenever possible (even when you think the description is clear). 
-    validations:
-      required: true
-  - type: textarea
-    id: expected_results
-    attributes:
-      label: Expected results
-      description: What should happen after the above steps?
-    validations:
-      required: true
-  - type: markdown
-    id: file_required
-    attributes:
-      value: |
-        Please be sure to add the following files:
-          * Please upload a ZIP archive containing the **project file** used when the problem arise. Please export it just before or after the problem occurs. Even if you did nothing and/or there is no object, export it! (We need the configurations in project file).
-            You can export the project file from the application menu in `File`->`Save project as...`, then zip it
-          * A **log file** for crashes and similar issues.
-            You can find your log file here:
-            Windows: `%APPDATA%\OrcaSlicer\log` or usually `C:\Users\<your username>\AppData\Roaming\OrcaSlicer\log`
-            MacOS: `$HOME/Library/Application Support/OrcaSlicer/log`
-            Linux: `$HOME/.config/OrcaSlicer/log`
-            If Orca Slicer still starts, you can also reach this directory from the application menu in `Help` -> `Show Configuration Folder`
-            You can zip the log directory, or just select the newest logs when this issue happens, and zip them
-  - type: textarea
-    id: file_uploads
-    attributes:
-      label: Project file & Debug log uploads
-      description:  Drop the project file and debug log here
-      placeholder: |
-        Project File: `File` -> `Save project as...` then zip it & drop it here
-        Log File:  `Help` -> `Show Configuration Folder`, then zip the log directory, or just select the newest logs in `log` when this issue happens and zip them, then drop the zip file here
-    validations:
-      required: true
-  - type: checkboxes
-    id: file_checklist
-    attributes:
-      label: Checklist of files to include
-      options:
-        - label: Log file
-        - label: Project file
-  - type: textarea
-    attributes:
-      label: Anything else?
-      description: |
-        Screenshots? References? Anything that will give us more context about the issue you are encountering!
+      required: false
 
-        Tip: You can attach images or log files by clicking this area to highlight it and then dragging files in.
+  - type: textarea
+    id: what_happened
+    attributes:
+      label: What happened
+      description: What you did, what you expected, what you got. Screenshots help.
+    validations:
+      required: true
+
+  - type: textarea
+    id: logs
+    attributes:
+      label: Logs / project file
+      description: |
+        Drag in a zip with the log directory and (if relevant) the project file.
+        Logs: `Help` → `Show Configuration Folder` → `log/`
     validations:
       required: false

--- a/.github/ISSUE_TEMPLATE/config.yml
+++ b/.github/ISSUE_TEMPLATE/config.yml
@@ -1,8 +1,8 @@
-blank_issues_enabled: false
+blank_issues_enabled: true
 contact_links:
-  - name: Community Support (Discord channel)
-    url: https://discord.gg/P4VE9UY9gJ
-    about: Please ask and answer support "how do I?"questions here.
-  - name: Discussion Forum
-    url: https://github.com/OrcaSlicer/OrcaSlicer/discussions
-    about: Please raise ideas and feature suggestions here.
+  - name: Discussion / questions
+    url: https://github.com/dennisklappe/OrcaSlicer-WaveOverhangs/discussions
+    about: Ask questions, share prints, or chat about wave overhangs here.
+  - name: Upstream OrcaSlicer issue
+    url: https://github.com/OrcaSlicer/OrcaSlicer/issues
+    about: For bugs in core OrcaSlicer behavior unrelated to wave overhangs, file upstream.

--- a/.github/ISSUE_TEMPLATE/feature_request.yml
+++ b/.github/ISSUE_TEMPLATE/feature_request.yml
@@ -1,66 +1,24 @@
-name: 🚀 Feature Request / Enhancement
-description: Suggest an improvement to make Orca Slicer even better!
+name: Feature Request
+description: Suggest something for OrcaSlicer-WaveOverhangs
 labels: ["enhancement"]
 body:
   - type: markdown
     attributes:
       value: |
-        Thanks for taking the time to fill out this feature request!
+        For ideas about general slicer behavior (not wave-overhang specific), please file upstream at [OrcaSlicer/OrcaSlicer](https://github.com/OrcaSlicer/OrcaSlicer/issues/new?template=feature_request.yml). This fork tracks features tied to wave-overhang printing.
 
-        If your idea is still at the formulation stage, or you're not sure it would
-        be useful to many users, you can raise it as a discussion topic under [Ideas](https://github.com/OrcaSlicer/OrcaSlicer/discussions/categories/ideas)
-        or you can raise it on the [Discord server](https://discord.gg/P4VE9UY9gJ).
-  - type: checkboxes
-    attributes:
-      label: Is there an existing issue for this feature request?
-      description: |
-        Please search to see if an issue already exists for a feature, or perhaps one similar.
-        You can then comment and react so that we know know much interest there is in the feature request.
-      options:
-        - label: I have searched the existing issues
-          required: true
   - type: textarea
+    id: what
     attributes:
-      label: Is your feature request related to a problem?
-      description: A clear and concise description of what the problem is.
-      placeholder: I'm always frustrated when [...]
+      label: What would you like
+      description: What should the slicer do, and why does it matter?
     validations:
       required: true
-  - type: dropdown
-    attributes:
-      label: Which printers will be beneficial to this feature?
-      description: Select affected printer firmware type.
-      multiple: true
-      options: 
-        - Klipper
-        - Marlin
-        - Others
-        - All
-    validations:
-      required: true
-  - type: textarea
-    attributes:
-      label: Describe the solution you'd like
-      description: A clear and concise description of what you want to happen.
-      placeholder: It should do [...]
-    validations:
-      required: true
-  - type: textarea
-    attributes:
-      label: Describe alternatives you've considered
-      description: A clear and concise description of any alternative solutions or features you've considered.
-      placeholder: |
-        1. [...]
-        2. [...]
-        3. [...]
-    validations:
-      required: false
-  - type: textarea
-    attributes:
-      label: Additional context
-      description: |
-        Add any other context, diagrams, illustations or screenshots about the feature request here.
 
-        Tip: You can attach images or log files by clicking this area to highlight it and then dragging files in.
+  - type: textarea
+    id: context
+    attributes:
+      label: Anything else
+      description: Sketches, references, related tools, optional.
     validations:
       required: false


### PR DESCRIPTION
## Summary
- Replace upstream Orca's `bug_report.yml` (10+ fields) and `feature_request.yml` with short fork-branded versions (5 and 2 fields).
- `config.yml`: drop upstream Discord link, point discussions at this fork, enable blank issues for "other".
- Keep `wave_overhang_bug.yml` as is.