### PR TITLE
docs: lift video + WAN Show callout out of centered hero

### DIFF
--- a/README.md
+++ b/README.md
@@ -11,20 +11,22 @@ Fork of OrcaSlicer with wave‑pattern overhang printing, two pluggable algorith
 
 <br>
 
-https://github.com/user-attachments/assets/c9d8f19e-277a-43d4-9078-1988bb0c89c0
-
-<sub><i>Wave overhangs in action: a 90° cantilever printing without any support material. <a href="https://www.reddit.com/r/3Dprinting/comments/1t2qskk/overhangs_that_flow_like_waves_no_supports/">Original Reddit post.</a></i></sub>
-
-<br>
-
 [![Download](https://img.shields.io/github/v/release/dennisklappe/OrcaSlicer-WaveOverhangs?include_prereleases&label=Download&color=brightgreen&style=for-the-badge)](https://github.com/dennisklappe/OrcaSlicer-WaveOverhangs/releases)
 [![Build](https://img.shields.io/github/actions/workflow/status/dennisklappe/OrcaSlicer-WaveOverhangs/build_all.yml?branch=main&label=Build&style=for-the-badge)](https://github.com/dennisklappe/OrcaSlicer-WaveOverhangs/actions/workflows/build_all.yml)
 [![Stars](https://img.shields.io/github/stars/dennisklappe/OrcaSlicer-WaveOverhangs?style=for-the-badge)](https://github.com/dennisklappe/OrcaSlicer-WaveOverhangs/stargazers)
 [![License](https://img.shields.io/badge/license-AGPL--3.0-blue?style=for-the-badge)](https://github.com/OrcaSlicer/OrcaSlicer/blob/main/LICENSE.txt)
 
-> **As featured on [The WAN Show](https://www.youtube.com/live/0xp-pOVTrsI?t=5785) with Linus Sebastian and Luke Lafreniere** (Topic #6, 1:36:26 - 1:41:44).
-
 > **⚠️ Experimental / Alpha.** Feedback and test prints welcome. Open an issue with your results.
+
+</div>
+
+<div align="center">
+
+https://github.com/user-attachments/assets/c9d8f19e-277a-43d4-9078-1988bb0c89c0
+
+<sub><i>Wave overhangs in action: a 90° cantilever printing without any support material. <a href="https://www.reddit.com/r/3Dprinting/comments/1t2qskk/overhangs_that_flow_like_waves_no_supports/">Original Reddit post.</a></i></sub>
+
+**As featured on [The WAN Show](https://www.youtube.com/live/0xp-pOVTrsI?t=5785) with Linus Sebastian and Luke Lafreniere** (Topic #6, 1:36:26 - 1:41:44).
 
 </div>
 


### PR DESCRIPTION
Move both out of the centered `<div>` so the waveoverhangs.com homepage (which strips that div to show its own hero) actually renders them. On GitHub they go from centered under the badges to left-aligned just below the badges; otherwise unchanged.