### PR TITLE
Fix Linux AppImage not opening on Mint / clean Ubuntu

### DIFF
--- a/README.md
+++ b/README.md
@@ -67,6 +67,8 @@ This fork ports the technique into OrcaSlicer and exposes two pluggable generato
 
 Prebuilt binaries for tagged releases on the **[Releases page](https://github.com/dennisklappe/OrcaSlicer-WaveOverhangs/releases)**. Linux AppImage, Windows portable zip + installer, macOS universal DMG.
 
+**Linux:** make the AppImage executable (`chmod +x OrcaSlicerWaveOverhangs_Linux_*.AppImage`) before running it. If it fails to start with a missing shared library, run it from a terminal to see which library is missing and install the matching distro package. Common ones: `libwebpdecoder3`, `libwebp7`, `libheif1` (Debian/Ubuntu/Mint package names; other distros vary).
+
 ---
 
 ## Using wave overhangs

--- a/scripts/appimage_lib_policy.sh
+++ b/scripts/appimage_lib_policy.sh
@@ -14,7 +14,14 @@ appimage_is_host_library() {
         libfontconfig.so*|libfreetype.so*|libharfbuzz*.so*|libfribidi.so*|libgraphite2.so*|libthai.so*|libdatrie.so*|libepoxy.so*|libpixman-1.so*|\
         libstdc++.so*|libgcc_s.so*|libatomic.so*|libdbus-1.so*|libuuid.so*|libffi.so*|libselinux.so*|libmount.so*|libblkid.so*|libpcre2-*.so*|libsystemd.so*|libcap.so*|libseccomp.so*|\
         liborc-0.4.so*|libgudev-1.0.so*|\
-        libavif.so*|libsharpyuv.so*|libheif.so*|libwebp.so*|libwebpdemux.so*|libwebpmux.so*|libwebpdecoder.so*)
+        libavif.so*|libsharpyuv.so*|libheif.so*|libwebp.so*|libwebpdemux.so*|libwebpmux.so*)
+            # Note: libwebpdecoder.so* is deliberately NOT host-resolved. It is the
+            # decode-only webp library, a direct dependency of the slicer binary, and
+            # is not part of the host gdk-pixbuf loader stack. Ubuntu ships it in a
+            # standalone libwebpdecoder3 package that many distros (Linux Mint, clean
+            # Ubuntu) do not install by default, so the AppImage must bundle it. It
+            # has no libsharpyuv dependency, so the avif/sharpyuv ABI mismatch that
+            # made the other codec libs host-resolved does not apply here.
             return 0
             ;;
         *)


### PR DESCRIPTION
The Linux AppImage doesn't open on Mint or clean Ubuntu because it expects libwebpdecoder3 to already be installed on the system. This bundles that library into the AppImage so it just works out of the box. Also added a short Linux note to the README.

(The issue title says Flatpak, but it's actually the AppImage.)

Closes #66.