### PR TITLE
docs: clarify wave overhangs work on angled overhangs too

### DIFF
--- a/README.md
+++ b/README.md
@@ -40,6 +40,8 @@ Wave overhangs replace those supports with a different toolpath. Instead of stra
 
 The result: support‑free overhangs up to 90°, less wasted filament, and no post‑processing snap‑off step.
 
+**Angled overhangs work too.** The wave isn't restricted to fully horizontal overhangs. Any perimeter Orca classifies as overhang (geometrically: the extrusion extends past the layer below) becomes a candidate for wave, and there's no minimum angle setting. Practically, the wave only fills the unsupported portion of each layer, so a mild 50° wall only sees wave activity on the small lip that protrudes past the previous layer, while an 85° near‑horizontal cantilever sees wave across most of it.
+
 This fork ports the technique into OrcaSlicer and exposes a large tunable parameter space, so people can experiment and find what works for their printer and material.
 
 ![Standard vs arc vs wave overhangs](docs/images/fig_2_compare_standard_arc_and_wave_overhangs.png)

--- a/docs/WAVE_OVERHANG_SETTINGS.md
+++ b/docs/WAVE_OVERHANG_SETTINGS.md
@@ -26,6 +26,8 @@ This document describes every config option added by the wave-overhangs fork of 
 
 Wave overhangs let you print steep cantilevered overhangs without supports. Instead of dropping support columns from the bed, each ring of extrusion anchors to the one before it and the nozzle marches outward into empty space one fused-plastic rung at a time. The generator emits expanding wavefronts seeded at the supported edge of the overhang.
 
+**Wave overhangs are angle-agnostic.** The trigger is geometric, not an angle threshold: any perimeter Orca's *Strength → Detect overhang walls* + *Overhang reverse threshold* pipeline flags as overhang becomes a candidate for wave. So angled overhangs (slopes anywhere between vertical and fully horizontal) are supported, with the wave only filling the part of each layer that protrudes past the previous one. The `wave_overhang_min_angle` setting on the profile is inert (kept for compat); see its entry under [General](#general) below for the rationale.
+
 ## How to enable
 
 1. Open a model with an overhang.


### PR DESCRIPTION
Closes #78.

Adds a short paragraph to README.md and docs/WAVE_OVERHANG_SETTINGS.md stating that wave engagement is geometric (any perimeter Orca flags as overhang qualifies), so angled overhangs between vertical and fully horizontal are supported, and the wave only fills the unsupported lip of each layer.