### PR TITLE
feat(wave-overhangs): linear floor-layer speed ramp

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,9 @@ Format: [Keep a Changelog](https://keepachangelog.com/en/1.1.0/). Versioning fol
 
 ## [Unreleased]
 
+### Added
+- **Floor-layer speed ramp.** New `wave_overhang_floor_speed_ramp` config (default 0 = step function, current behaviour) interpolates `wave_overhang_floor_print_speed` and `wave_overhang_floor_perimeter_speed` linearly from the override speed back up to the normal speed across N layers above the wave. Distance is stamped per-extrusion during the existing tagging pass. Helpful for releasing warping stress gradually instead of at a single layer boundary (closes #77).
+
 ### Removed
 - **Algorithm selector and second wave-overhang algorithm removed.** Wave overhangs now ships as a single generator. The `wave_overhang_algorithm` config key and the Kaiser/LaSO generator are gone; the `wave_overhang_ring_overlap` key (only used by the removed generator) is gone too.
 - **Algorithm-name branding stripped from the UI.** Tooltips, settings labels, docs, README, and the issue template no longer reference specific algorithm names; the feature is described generically as "wave overhangs".

--- a/src/libslic3r/ExtrusionEntity.hpp
+++ b/src/libslic3r/ExtrusionEntity.hpp
@@ -172,6 +172,11 @@ public:
     // G-code applies wave_overhang_floor_perimeter_speed to reduce warping driven by
     // fast walls printed on top of the still-fragile wave shadow.
     bool wave_overhang_floor_perimeter = false;
+    // 1-based distance (in layers) from the nearest wave layer below this path, when
+    // this path is on a wave-overhang floor layer; 0 otherwise. Consumed by G-code
+    // together with wave_overhang_floor_speed_ramp to interpolate floor speeds from
+    // the override back up to the normal speed across N layers.
+    int8_t wave_overhang_floor_distance = 0;
 
     ExtrusionPath() : mm3_per_mm(-1), width(-1), height(-1), m_role(erNone), m_no_extrusion(false) {}
     ExtrusionPath(ExtrusionRole role) : mm3_per_mm(-1), width(-1), height(-1), m_role(role), m_no_extrusion(false) {}
@@ -186,6 +191,7 @@ public:
         , wave_overhang_floor(rhs.wave_overhang_floor)
         , wave_overhang_perimeter(rhs.wave_overhang_perimeter)
         , wave_overhang_floor_perimeter(rhs.wave_overhang_floor_perimeter)
+        , wave_overhang_floor_distance(rhs.wave_overhang_floor_distance)
         , m_can_reverse(rhs.m_can_reverse)
         , m_role(rhs.m_role)
         , m_no_extrusion(rhs.m_no_extrusion)
@@ -199,6 +205,7 @@ public:
         , wave_overhang_floor(rhs.wave_overhang_floor)
         , wave_overhang_perimeter(rhs.wave_overhang_perimeter)
         , wave_overhang_floor_perimeter(rhs.wave_overhang_floor_perimeter)
+        , wave_overhang_floor_distance(rhs.wave_overhang_floor_distance)
         , m_can_reverse(rhs.m_can_reverse)
         , m_role(rhs.m_role)
         , m_no_extrusion(rhs.m_no_extrusion)
@@ -212,6 +219,7 @@ public:
         , wave_overhang_floor(rhs.wave_overhang_floor)
         , wave_overhang_perimeter(rhs.wave_overhang_perimeter)
         , wave_overhang_floor_perimeter(rhs.wave_overhang_floor_perimeter)
+        , wave_overhang_floor_distance(rhs.wave_overhang_floor_distance)
         , m_can_reverse(rhs.m_can_reverse)
         , m_role(rhs.m_role)
         , m_no_extrusion(rhs.m_no_extrusion)
@@ -225,6 +233,7 @@ public:
         , wave_overhang_floor(rhs.wave_overhang_floor)
         , wave_overhang_perimeter(rhs.wave_overhang_perimeter)
         , wave_overhang_floor_perimeter(rhs.wave_overhang_floor_perimeter)
+        , wave_overhang_floor_distance(rhs.wave_overhang_floor_distance)
         , m_can_reverse(rhs.m_can_reverse)
         , m_role(rhs.m_role)
         , m_no_extrusion(rhs.m_no_extrusion)
@@ -241,6 +250,7 @@ public:
         this->wave_overhang_floor = rhs.wave_overhang_floor;
         this->wave_overhang_perimeter = rhs.wave_overhang_perimeter;
         this->wave_overhang_floor_perimeter = rhs.wave_overhang_floor_perimeter;
+        this->wave_overhang_floor_distance = rhs.wave_overhang_floor_distance;
         this->polyline = rhs.polyline;
         return *this;
     }
@@ -255,6 +265,7 @@ public:
         this->wave_overhang_floor = rhs.wave_overhang_floor;
         this->wave_overhang_perimeter = rhs.wave_overhang_perimeter;
         this->wave_overhang_floor_perimeter = rhs.wave_overhang_floor_perimeter;
+        this->wave_overhang_floor_distance = rhs.wave_overhang_floor_distance;
         this->polyline = std::move(rhs.polyline);
         return *this;
     }

--- a/src/libslic3r/Fill/Fill.cpp
+++ b/src/libslic3r/Fill/Fill.cpp
@@ -26,18 +26,21 @@ namespace Slic3r {
 // wave-overhang-floor path. Used to mark Hilbert-pattern infill on the solid
 // floor layers above wave overhangs so the G-code stage applies the
 // wave_overhang_floor_print_speed and wave_overhang_floor_fan_speed overrides.
-static void tag_wave_overhang_floor_recursive(ExtrusionEntity *ent)
+// `distance` is the 1-based layer offset from the nearest wave layer below;
+// G-code interpolates against wave_overhang_floor_speed_ramp using this.
+static void tag_wave_overhang_floor_recursive(ExtrusionEntity *ent, int8_t distance)
 {
     if (!ent) return;
-    if (auto *path = dynamic_cast<ExtrusionPath*>(ent)) {
-        path->wave_overhang_floor = true;
-    } else if (auto *loop = dynamic_cast<ExtrusionLoop*>(ent)) {
-        for (ExtrusionPath &p : loop->paths) p.wave_overhang_floor = true;
-    } else if (auto *mp = dynamic_cast<ExtrusionMultiPath*>(ent)) {
-        for (ExtrusionPath &p : mp->paths) p.wave_overhang_floor = true;
-    } else if (auto *coll = dynamic_cast<ExtrusionEntityCollection*>(ent)) {
+    auto stamp = [distance](ExtrusionPath &p) {
+        p.wave_overhang_floor = true;
+        p.wave_overhang_floor_distance = distance;
+    };
+    if (auto *path = dynamic_cast<ExtrusionPath*>(ent))         { stamp(*path); }
+    else if (auto *loop = dynamic_cast<ExtrusionLoop*>(ent))    { for (ExtrusionPath &p : loop->paths) stamp(p); }
+    else if (auto *mp = dynamic_cast<ExtrusionMultiPath*>(ent)) { for (ExtrusionPath &p : mp->paths) stamp(p); }
+    else if (auto *coll = dynamic_cast<ExtrusionEntityCollection*>(ent)) {
         for (ExtrusionEntity *child : coll->entities)
-            tag_wave_overhang_floor_recursive(child);
+            tag_wave_overhang_floor_recursive(child, distance);
     }
 }
 
@@ -294,6 +297,10 @@ struct SurfaceFillParams
     // Used by Layer::make_fills() to tag produced ExtrusionPaths so the G-code stage
     // applies wave_overhang_floor_print_speed / wave_overhang_floor_fan_speed overrides.
     bool wave_overhang_floor = false;
+    // Orca: 1-based layer distance from the nearest wave layer below; 0 when not a
+    // wave-overhang floor. Tagged onto produced ExtrusionPaths so G-code can ramp the
+    // floor print speed across wave_overhang_floor_speed_ramp layers.
+    int8_t wave_overhang_floor_distance = 0;
 
 	bool operator<(const SurfaceFillParams &rhs) const {
 #define RETURN_COMPARE_NON_EQUAL(KEY) if (this->KEY < rhs.KEY) return true; if (this->KEY > rhs.KEY) return false;
@@ -328,6 +335,7 @@ struct SurfaceFillParams
 		RETURN_COMPARE_NON_EQUAL(infill_lock_depth);
 		RETURN_COMPARE_NON_EQUAL(skin_infill_depth);		RETURN_COMPARE_NON_EQUAL(infill_overhang_angle);
 		RETURN_COMPARE_NON_EQUAL_TYPED(unsigned, wave_overhang_floor);
+		RETURN_COMPARE_NON_EQUAL_TYPED(int, wave_overhang_floor_distance);
 
 		return false;
 	}
@@ -356,7 +364,8 @@ struct SurfaceFillParams
 				this->infill_lock_depth      ==  rhs.infill_lock_depth &&
 				this->skin_infill_depth      ==  rhs.skin_infill_depth &&
                 this->infill_overhang_angle == rhs.infill_overhang_angle &&
-                this->wave_overhang_floor   == rhs.wave_overhang_floor;
+                this->wave_overhang_floor   == rhs.wave_overhang_floor &&
+                this->wave_overhang_floor_distance == rhs.wave_overhang_floor_distance;
 	}
 };
 
@@ -949,6 +958,7 @@ std::vector<SurfaceFill> group_fills(const Layer &layer, LockRegionParam &lock_p
                                         params.pattern = ipHilbertCurve;
                                         params.density = float(std::clamp(region_config.wave_overhang_floor_hilbert_density.value, 1, 100));
                                         params.wave_overhang_floor = true;
+                                        params.wave_overhang_floor_distance = static_cast<int8_t>(std::min(k, 127));
                                     }
                                 }
                             }
@@ -1394,8 +1404,9 @@ void Layer::make_fills(FillAdaptive::Octree* adaptive_fill_octree, FillAdaptive:
 		// Orca: now tag every newly-produced path/loop/multi-path/sub-collection if
 		// this SurfaceFill represented a wave-overhang Hilbert floor.
 		if (surface_fill.params.wave_overhang_floor) {
+			const int8_t dist = surface_fill.params.wave_overhang_floor_distance;
 			for (size_t i = wo_floor_dst_size_before; i < dst_entities.size(); ++i)
-				tag_wave_overhang_floor_recursive(dst_entities[i]);
+				tag_wave_overhang_floor_recursive(dst_entities[i], dist);
 		}
     }
 

--- a/src/libslic3r/GCode.cpp
+++ b/src/libslic3r/GCode.cpp
@@ -6684,7 +6684,18 @@ std::string GCode::_extrude(const ExtrusionPath &path, std::string description, 
         // Orca: wave-overhang Hilbert floor speed override. Slower print on the floor
         // layers gives each Hilbert line more time to dissipate heat before its
         // neighbours land, which reduces the residual thermal stress driving warping.
-        speed = m_config.wave_overhang_floor_print_speed.value;
+        // If wave_overhang_floor_speed_ramp > 0 and we know the layer's distance from
+        // the wave, linearly interpolate between the override (slowest, distance=1)
+        // and the normal speed (full, distance>=ramp) so the transition is gradual.
+        const double override_speed = m_config.wave_overhang_floor_print_speed.value;
+        const int    ramp           = m_config.wave_overhang_floor_speed_ramp.value;
+        const int    distance       = path.wave_overhang_floor_distance;
+        if (ramp > 0 && distance > 0) {
+            const double factor = std::min(double(distance) / double(ramp), 1.0);
+            speed = override_speed + (speed - override_speed) * factor;
+        } else {
+            speed = override_speed;
+        }
         variable_speed = false;
         new_points.clear();
     } else if (path.wave_overhang_perimeter && m_config.wave_overhang_perimeter_speed.value > 0) {
@@ -6697,8 +6708,18 @@ std::string GCode::_extrude(const ExtrusionPath &path, std::string description, 
     } else if (path.wave_overhang_floor_perimeter && m_config.wave_overhang_floor_perimeter_speed.value > 0) {
         // Orca: walls on floor layers above wave-overhang regions ride a fragile
         // shadow that warps with fast walls landing on top; slow them to keep the
-        // substrate near bed temperature and let thermal stress relax.
-        speed = m_config.wave_overhang_floor_perimeter_speed.value;
+        // substrate near bed temperature and let thermal stress relax. Mirrors the
+        // floor-print ramp above: if wave_overhang_floor_speed_ramp > 0, interpolate
+        // from the override (slowest, distance=1) back to the normal wall speed.
+        const double override_speed = m_config.wave_overhang_floor_perimeter_speed.value;
+        const int    ramp           = m_config.wave_overhang_floor_speed_ramp.value;
+        const int    distance       = path.wave_overhang_floor_distance;
+        if (ramp > 0 && distance > 0) {
+            const double factor = std::min(double(distance) / double(ramp), 1.0);
+            speed = override_speed + (speed - override_speed) * factor;
+        } else {
+            speed = override_speed;
+        }
         variable_speed = false;
         new_points.clear();
     }

--- a/src/libslic3r/Preset.cpp
+++ b/src/libslic3r/Preset.cpp
@@ -902,7 +902,7 @@ static std::vector<std::string> s_Preset_print_options {
     "wave_overhang_floor_use_hilbert", "wave_overhang_floor_hilbert_layers",
     "wave_overhang_floor_hilbert_density",
     "wave_overhang_floor_print_speed", "wave_overhang_floor_perimeter_speed", "wave_overhang_floor_fan_speed",
-    "wave_overhang_floor_aux_fan_speed",
+    "wave_overhang_floor_aux_fan_speed", "wave_overhang_floor_speed_ramp",
     "wave_overhang_min_angle",
     "wave_overhang_spacing_mode", "wave_overhang_seam_mode",
     "wave_overhang_debug_gcode", "wave_overhang_min_length",

--- a/src/libslic3r/PrintConfig.cpp
+++ b/src/libslic3r/PrintConfig.cpp
@@ -4926,6 +4926,29 @@ void PrintConfigDef::init_fff_params()
     def->max = 1000;
     def->set_default_value(new ConfigOptionFloat(0.0));
 
+    def = this->add("wave_overhang_floor_speed_ramp", coInt);
+    def->label = L("Floor speed ramp");
+    def->category = L("Speed");
+    def->tooltip = L("Number of layers over which the floor-layer speed overrides (Floor print speed "
+                     "and Floor perimeter speed) ramp linearly from the slow override speed back up "
+                     "to the normal print/wall speed.\n\n"
+                     "0 = step function (current behaviour): every floor layer prints at the override "
+                     "speed, then snaps back to normal on the next layer.\n"
+                     "1..N = layer 1 above the wave prints at the override speed, layer N (or the last "
+                     "floor layer, whichever comes first) prints at full normal speed, with linear "
+                     "interpolation in between.\n\n"
+                     "Helpful for releasing the thermal stress that builds up at the speed transition: "
+                     "the gradual ramp keeps each layer slightly warmer than the next as the print "
+                     "moves away from the wave shadow, so curl is spread across the ramp instead of "
+                     "concentrated at one boundary.\n\n"
+                     "Capped by Floor layers; if you set a ramp longer than the floor-layer count, "
+                     "the ramp ends at the top floor layer.");
+    def->sidetext = L("layers");
+    def->mode = comAdvanced;
+    def->min = 0;
+    def->max = 64;
+    def->set_default_value(new ConfigOptionInt(0));
+
     def = this->add("wave_overhang_floor_fan_speed", coInt);
     def->label = L("Hilbert floor fan speed");
     def->category = L("Cooling");

--- a/src/libslic3r/PrintConfig.hpp
+++ b/src/libslic3r/PrintConfig.hpp
@@ -1156,6 +1156,7 @@ PRINT_CONFIG_CLASS_DEFINE(
     ((ConfigOptionInt,                       wave_overhang_floor_hilbert_density))
     ((ConfigOptionFloat,                     wave_overhang_floor_print_speed))
     ((ConfigOptionFloat,                     wave_overhang_floor_perimeter_speed))
+    ((ConfigOptionInt,                       wave_overhang_floor_speed_ramp))
     ((ConfigOptionInt,                       wave_overhang_floor_fan_speed))
     ((ConfigOptionInt,                       wave_overhang_floor_aux_fan_speed))
     ((ConfigOptionInt,                       wave_overhang_nozzle_temp))

--- a/src/libslic3r/PrintObject.cpp
+++ b/src/libslic3r/PrintObject.cpp
@@ -2000,34 +2000,47 @@ void PrintObject::apply_wave_overhang_bridge_suppression()
 //   wave_overhang_floor_perimeter  : path lives on a layer in the wave shadow but is NOT a wave layer itself
 // ==============================================================================================================
 namespace {
-// Recursively flag every leaf ExtrusionPath inside an entity tree.
-static void tag_wave_overhang_perimeter_recursive(ExtrusionEntity *ent, bool floor_layer)
+// Recursively flag every leaf ExtrusionPath inside an entity tree. `distance` is the
+// 1-based layer offset from the nearest wave layer below (0 for wave layers themselves
+// and for non-floor layers); consumed by G-code together with
+// wave_overhang_floor_speed_ramp to interpolate floor speed back to normal.
+static void tag_wave_overhang_perimeter_recursive(ExtrusionEntity *ent, bool floor_layer, int8_t distance)
 {
     if (!ent) return;
-    auto stamp = [floor_layer](ExtrusionPath &p) {
-        if (floor_layer) p.wave_overhang_floor_perimeter = true;
-        else             p.wave_overhang_perimeter       = true;
+    auto stamp = [floor_layer, distance](ExtrusionPath &p) {
+        if (floor_layer) {
+            p.wave_overhang_floor_perimeter = true;
+            p.wave_overhang_floor_distance  = distance;
+        } else {
+            p.wave_overhang_perimeter = true;
+        }
     };
     if (auto *path = dynamic_cast<ExtrusionPath*>(ent))         { stamp(*path); }
     else if (auto *loop = dynamic_cast<ExtrusionLoop*>(ent))    { for (ExtrusionPath &p : loop->paths) stamp(p); }
     else if (auto *mp = dynamic_cast<ExtrusionMultiPath*>(ent)) { for (ExtrusionPath &p : mp->paths)   stamp(p); }
     else if (auto *coll = dynamic_cast<ExtrusionEntityCollection*>(ent))
-        for (ExtrusionEntity *child : coll->entities) tag_wave_overhang_perimeter_recursive(child, floor_layer);
+        for (ExtrusionEntity *child : coll->entities) tag_wave_overhang_perimeter_recursive(child, floor_layer, distance);
 }
 } // anonymous namespace
 
 void PrintObject::tag_wave_overhang_perimeters()
 {
     bool any_wave = false;
-    for (size_t region_id = 0; region_id < this->num_printing_regions(); ++ region_id)
-        if (this->printing_region(region_id).config().wave_overhangs.value) { any_wave = true; break; }
+    int  max_floor_layers = 0;
+    for (size_t region_id = 0; region_id < this->num_printing_regions(); ++ region_id) {
+        const PrintRegionConfig &rconf = this->printing_region(region_id).config();
+        if (rconf.wave_overhangs.value) {
+            any_wave = true;
+            max_floor_layers = std::max(max_floor_layers, rconf.wave_overhang_floor_layers.value);
+        }
+    }
     if (!any_wave)
         return;
 
     BOOST_LOG_TRIVIAL(info) << "Tagging wave-overhang perimeters...";
 
     tbb::parallel_for(tbb::blocked_range<size_t>(0, m_layers.size()),
-        [this](const tbb::blocked_range<size_t> &range) {
+        [this, max_floor_layers](const tbb::blocked_range<size_t> &range) {
             for (size_t idx_layer = range.begin(); idx_layer < range.end(); ++ idx_layer) {
                 m_print->throw_if_canceled();
                 Layer *layer = m_layers[idx_layer];
@@ -2035,11 +2048,27 @@ void PrintObject::tag_wave_overhang_perimeters()
                 const bool is_floor_layer = !is_wave_layer && !layer->wave_overhang_shadow_polygons.empty();
                 if (!is_wave_layer && !is_floor_layer)
                     continue;
+                // For floor layers, find the closest wave layer below within the
+                // floor-layer window. The distance is 1-based: 1 = directly above the
+                // wave, 2 = one layer further up, etc. Capped at max_floor_layers
+                // across all regions. 0 stays as "no ramp data" so existing step-function
+                // behaviour is unaffected when the ramp config is 0.
+                int8_t distance = 0;
+                if (is_floor_layer && max_floor_layers > 0) {
+                    const int search_limit = std::min<int>(max_floor_layers, 127);
+                    for (int k = 1; k <= search_limit; ++k) {
+                        if ((int)idx_layer - k < 0) break;
+                        if (!m_layers[idx_layer - k]->wave_overhang_floor_polygons.empty()) {
+                            distance = static_cast<int8_t>(k);
+                            break;
+                        }
+                    }
+                }
                 for (size_t region_id = 0; region_id < this->num_printing_regions(); ++ region_id) {
                     if (!this->printing_region(region_id).config().wave_overhangs.value)
                         continue;
                     LayerRegion *layerm = layer->m_regions[region_id];
-                    tag_wave_overhang_perimeter_recursive(&layerm->perimeters, is_floor_layer);
+                    tag_wave_overhang_perimeter_recursive(&layerm->perimeters, is_floor_layer, distance);
                 }
             }
         });

--- a/src/slic3r/GUI/ConfigManipulation.cpp
+++ b/src/slic3r/GUI/ConfigManipulation.cpp
@@ -985,6 +985,7 @@ void ConfigManipulation::toggle_print_fff_options(DynamicPrintConfig *config, co
         std::string("wave_overhang_min_layer_time"),
         std::string("wave_overhang_floor_layers"),
         std::string("wave_overhang_floor_perimeter_speed"),
+        std::string("wave_overhang_floor_speed_ramp"),
         std::string("wave_overhang_floor_use_hilbert"),
         std::string("wave_overhang_min_angle"),
         std::string("wave_overhang_min_length"),

--- a/src/slic3r/GUI/Tab.cpp
+++ b/src/slic3r/GUI/Tab.cpp
@@ -2463,6 +2463,7 @@ void TabPrint::build()
         optgroup->append_single_option_line("wave_overhang_floor_hilbert_density");
         optgroup->append_single_option_line("wave_overhang_floor_print_speed");
         optgroup->append_single_option_line("wave_overhang_floor_perimeter_speed");
+        optgroup->append_single_option_line("wave_overhang_floor_speed_ramp");
         optgroup->append_single_option_line("wave_overhang_floor_fan_speed");
         optgroup->append_single_option_line("wave_overhang_floor_aux_fan_speed");
 


### PR DESCRIPTION
Closes #77.

Adds wave_overhang_floor_speed_ramp (int, default 0 = current step behaviour). When non-zero, the existing wave_overhang_floor_perimeter_speed and wave_overhang_floor_print_speed overrides interpolate linearly from the slow override back up to the normal speed across N layers above the wave shadow.

Per-extrusion floor-layer distance is stamped during the existing tagging passes. Local build still in progress at push time, relying on CI for the full validation.