### PR TITLE
fix(gcode): emit wave-overhang debug keys outside HEADER_BLOCK (#74)

### DIFF
--- a/src/libslic3r/GCode.cpp
+++ b/src/libslic3r/GCode.cpp
@@ -2506,7 +2506,15 @@ void GCode::_do_export(Print& print, GCodeOutputStream &file, ThumbnailsGenerato
         // Orca: wave-overhang debug block — when any region has wave_overhangs
         // enabled AND debug-gcode is on, dump the active settings so post-
         // processing / tuning reports can verify exactly what ran.
-        {
+        //
+        // Emitted *after* HEADER_BLOCK_END (see the call below), never inside the
+        // header block itself: firmware parsers read HEADER_BLOCK and some reject
+        // a file outright when they meet keys they don't know. The Flashforge AD5X
+        // reported this as "No filament detected" (#74) and the Snapmaker U1 as
+        // "Invalid gcode" (#76). Keeping HEADER_BLOCK byte-for-byte the same shape
+        // as stock OrcaSlicer's is what makes our g-code portable; anything
+        // fork-specific belongs outside it.
+        auto write_wave_overhang_debug_block = [&]() {
             // Determine if any region uses wave overhangs with debug enabled.
             bool any_wave_debug = false;
             for (const PrintRegion *region : print.m_print_regions) {
@@ -2597,7 +2605,7 @@ void GCode::_do_export(Print& print, GCodeOutputStream &file, ThumbnailsGenerato
                     ++region_idx;
                 }
             }
-        }
+        };
         if (is_bbl_printers)
             file.write_format(";%s\n", GCodeProcessor::reserved_tag(GCodeProcessor::ETags::Estimated_Printing_Time_Placeholder).c_str());
         //BBS: total layer number
@@ -2656,6 +2664,9 @@ void GCode::_do_export(Print& print, GCodeOutputStream &file, ThumbnailsGenerato
     }
 
     file.write_format("; HEADER_BLOCK_END\n\n");
+
+    // Orca: fork-specific debug keys go here, outside HEADER_BLOCK.
+    write_wave_overhang_debug_block();
     }
     
       // BBS: write global config at the beginning of gcode file because printer


### PR DESCRIPTION
Follow-up to #79.

## Problem

The fork writes its `; WAVE_OVERHANG_BUILD` / `; WAVE_OVERHANG_CONFIG` lines **inside** the `HEADER_BLOCK_START`/`HEADER_BLOCK_END` region. Several printer firmwares parse that block and reject the file when they hit keys they don't recognise:

- Flashforge AD5X — surfaces as "No filament detected", printer aborts and unloads filament (#74)
- Snapmaker U1 — surfaces as "Invalid gcode" (#76)

#76 is the confirming evidence that firmware validates this block rather than skipping comments: that reporter's workaround was editing **only** line 2 of the header.

Ruled out from the reporter's attached g-code in #74: the largest negative extrusion in the entire file is `E-3` (standard end-gcode retract), so the filament retraction they observe is the printer unloading after it aborts, not something we emit.

## Change

Move the debug emission into a lambda invoked just after `HEADER_BLOCK_END`, so `HEADER_BLOCK` matches stock OrcaSlicer's shape exactly. Same content, same ordering, one block later — prefix-based parsers of those lines are unaffected.

## Verification

- [x] Brace depth across `GCode.cpp` identical to `HEAD`; lambda declared and called at the same scope level inside `if(!has_BTT_thumbnail)`
- [ ] **Not compiled locally** — no `build/`, `deps/` unbuilt. Relying on CI.
- [ ] **Not confirmed to fix #74** — no AD5X hardware. The AD5X root cause is inferred by analogy to #76, not proven.
- [ ] No test added — no existing coverage for header emission; a new one needs a full `Print` export in the `fff_print` harness.

## Note

A website parser reportedly consumes `WAVE_OVERHANG_CONFIG` for tuning reports. Prefix matching is unaffected; if it assumes the lines sit inside `HEADER_BLOCK`, it needs a matching tweak.