### PR TITLE
Fix recurring Linux device, assembly, and shutdown crashes

### DIFF
--- a/src/slic3r/GUI/GLCanvas3D.cpp
+++ b/src/slic3r/GUI/GLCanvas3D.cpp
@@ -8926,8 +8926,16 @@ void GLCanvas3D::_render_assemble_control()
         GLVolume::explosion_ratio = m_explosion_ratio = 1.0;
         return;
     }
+
+    // The assembly canvas may be rendered for one frame before its clipper has
+    // been created (or while it is being torn down).
+    auto* assemble_view_data = m_gizmos.m_assemble_view_data.get();
+    auto* model_objects_clipper = assemble_view_data == nullptr ? nullptr : assemble_view_data->model_objects_clipper();
+    if (model_objects_clipper == nullptr)
+        return;
+
     if (m_gizmos.get_current_type() == GLGizmosManager::EType::MmSegmentation) {
-        m_gizmos.m_assemble_view_data->model_objects_clipper()->set_position(0.0, true);
+        model_objects_clipper->set_position(0.0, true);
         return;
     }
 
@@ -8964,7 +8972,7 @@ void GLCanvas3D::_render_assemble_control()
     }
     float same_line_width = tip_icon_size;
     {
-        float clp_dist = m_gizmos.m_assemble_view_data->model_objects_clipper()->get_position();
+        float clp_dist = model_objects_clipper->get_position();
         if (clp_dist == 0.f) {
             ImGui::AlignTextToFramePadding();
             imgui->text(_L("Section View"));
@@ -8972,7 +8980,10 @@ void GLCanvas3D::_render_assemble_control()
         else {
             if (imgui->button(_L("Reset direction"))) {
                 wxGetApp().CallAfter([this]() {
-                    m_gizmos.m_assemble_view_data->model_objects_clipper()->set_position(-1., false);
+                    auto* data = m_gizmos.m_assemble_view_data.get();
+                    auto* clipper = data == nullptr ? nullptr : data->model_objects_clipper();
+                    if (clipper != nullptr)
+                        clipper->set_position(-1., false);
                     });
             }
         }
@@ -8987,7 +8998,7 @@ void GLCanvas3D::_render_assemble_control()
         bool view_input_changed = ImGui::BBLDragFloat("##clp_dist_input", &clp_dist, 0.05f, 0.0f, 0.0f, "%.2f");
 
         if (view_slider_changed || view_input_changed)
-            m_gizmos.m_assemble_view_data->model_objects_clipper()->set_position(clp_dist, true);
+            model_objects_clipper->set_position(clp_dist, true);
 
         same_line_width += (value_size + item_spacing * 2);
     }

--- a/src/slic3r/GUI/GUI_ObjectList.cpp
+++ b/src/slic3r/GUI/GUI_ObjectList.cpp
@@ -6297,6 +6297,11 @@ void ObjectList::OnEditingStarted(wxDataViewEvent &event)
 
 void ObjectList::OnEditingDone(wxDataViewEvent &event)
 {
+    // wxGTK may emit EDITING_DONE after the plater's canvas state has already
+    // been reset during application shutdown.
+    if (wxGetApp().is_closing())
+        return;
+
     if (event.GetColumn() != colName)
         return;
 

--- a/src/slic3r/GUI/PrinterWebView.cpp
+++ b/src/slic3r/GUI/PrinterWebView.cpp
@@ -24,6 +24,91 @@ namespace pt = boost::property_tree;
 namespace Slic3r {
 namespace GUI {
 
+#ifdef __linux__
+// Workaround for crash in WebKitGTK when loading Fluidd < v1.37.0 or Mainsail < v2.16.1.
+// Their bundled vue-resize component detects container resizes by inserting
+//   <object aria-hidden="true" tabindex="-1" type="text/html" data="about:blank">
+// inside a <div class="resize-observer">. The very insertion of that <object> into the DOM
+// corrupts the heap in WebKitGTK's AcceleratedBackingStore and segfaults.
+//
+// This hook patches Node.prototype.appendChild/insertBefore and *only* swaps the child
+// when BOTH conditions hold:
+//   1. The parent has class "resize-observer" (vue-resize's wrapper div), AND
+//   2. The child is an <object> with vue-resize's exact attribute signature.
+// Any other appendChild/insertBefore call passes through untouched, so PDF/plugin/embed
+// <object> uses elsewhere on the page are not affected.
+//
+// The swap replaces the <object> with a hidden <div> shim that exposes a synthetic
+// contentDocument.defaultView (an EventTarget), and bridges a ResizeObserver on the
+// parent to fire 'resize' events on that fake view -- which is exactly what vue-resize's
+// addResizeHandlers listens to. The synthetic 'load' event fires after insertion so
+// vue-resize wires up its handlers normally.
+//
+// See: https://github.com/OrcaSlicer/OrcaSlicer/issues/7210
+static void inject_vue_resize_workaround(wxWebView *webView)
+{
+    webView->AddUserScript(
+        "(function() {"
+        "  'use strict';"
+        "  function isVueResizeObject(el) {"
+        "    return el && el.tagName === 'OBJECT'"
+        "        && el.type === 'text/html'"
+        "        && el.getAttribute('aria-hidden') === 'true'"
+        "        && el.getAttribute('tabindex') === '-1';"
+        "  }"
+        "  function isResizeObserverParent(p) {"
+        "    return p && p.classList && p.classList.contains('resize-observer');"
+        "  }"
+        "  function makeShim(orig, parentForRO) {"
+        "    var shim = document.createElement('div');"
+        "    shim.setAttribute('aria-hidden', 'true');"
+        "    shim.setAttribute('tabindex', '-1');"
+        "    shim.style.display = 'none';"
+        "    var fakeWin = document.createElement('div');"
+        "    Object.defineProperty(shim, 'contentDocument', {"
+        "      configurable: true,"
+        "      get: function() { return { defaultView: fakeWin }; }"
+        "    });"
+        "    Object.defineProperty(shim, 'contentWindow', {"
+        "      configurable: true,"
+        "      get: function() { return fakeWin; }"
+        "    });"
+        "    if (typeof orig.onload === 'function') { shim.onload = orig.onload; }"
+        "    queueMicrotask(function() {"
+        "      if (parentForRO && typeof ResizeObserver !== 'undefined') {"
+        "        var ro = new ResizeObserver(function() {"
+        "          fakeWin.dispatchEvent(new Event('resize'));"
+        "        });"
+        "        ro.observe(parentForRO);"
+        "      }"
+        "      if (typeof shim.onload === 'function') {"
+        "        try { shim.onload(new Event('load')); } catch (e) {}"
+        "      }"
+        "      shim.dispatchEvent(new Event('load'));"
+        "    });"
+        "    return shim;"
+        "  }"
+        "  var origAppend = Node.prototype.appendChild;"
+        "  Node.prototype.appendChild = function(child) {"
+        "    if (isResizeObserverParent(this) && isVueResizeObject(child)) {"
+        "      return origAppend.call(this, makeShim(child, this));"
+        "    }"
+        "    return origAppend.call(this, child);"
+        "  };"
+        "  var origInsertBefore = Node.prototype.insertBefore;"
+        "  Node.prototype.insertBefore = function(child, ref) {"
+        "    if (isResizeObserverParent(this) && isVueResizeObject(child)) {"
+        "      return origInsertBefore.call(this, makeShim(child, this), ref);"
+        "    }"
+        "    return origInsertBefore.call(this, child, ref);"
+        "  };"
+        "  console.log('[vr-fix] vue-resize WebKitGTK patch active');"
+        "})();",
+        wxWEBVIEW_INJECT_AT_DOCUMENT_START
+    );
+}
+#endif
+
 PrinterWebView::PrinterWebView(wxWindow *parent)
         : wxPanel(parent, wxID_ANY, wxDefaultPosition, wxDefaultSize)
  {
@@ -38,6 +123,8 @@ PrinterWebView::PrinterWebView(wxWindow *parent)
     }
 
 #ifdef __linux__
+    inject_vue_resize_workaround(m_browser);
+
     auto cookiesPath = boost::filesystem::path(data_dir() + "/cache/cookies.db");
     auto wv = static_cast<WebKitWebView*>(m_browser->GetNativeBackend());
     auto wv_ctx = webkit_web_view_get_context(wv);
@@ -151,6 +238,10 @@ void PrinterWebView::SendAPIKey()
 )",
                                        m_apikey);
     m_browser->RemoveAllUserScripts();
+#ifdef __linux__
+    // Re-inject the vue-resize/WebKitGTK workaround that RemoveAllUserScripts just cleared.
+    inject_vue_resize_workaround(m_browser);
+#endif
 
     m_browser->AddUserScript(script);
     m_browser->Reload();


### PR DESCRIPTION
# Description

Fix three independent crash paths observed in the Linux v0.4.0 AppImage:

1. Backport OrcaSlicer's targeted WebKitGTK workaround for the hidden `vue-resize` `<object>` probe used by Mainsail < 2.16.1 and Fluidd < 1.37.0. The workaround is injected at document start and restored after `RemoveAllUserScripts()`. This is the reviewed fix from OrcaSlicer/OrcaSlicer#13724 for OrcaSlicer/OrcaSlicer#7210.
2. Guard the assembly controls until both `m_assemble_view_data` and its `model_objects_clipper()` are available. The asynchronous reset callback performs the same lifetime check before dereferencing the clipper.
3. Ignore late wxGTK `EDITING_DONE` events after application shutdown begins, before the callback can mark an already-reset plater canvas dirty.

The changes do not modify Wave Overhangs slicing behavior, presets, translations, or profile formats.

## Crash evidence

- Two dumps entered WebKit/JSC from the embedded Mainsail 2.14.0 device page and matched the `vue-resize` crash addressed upstream.
- One dump faulted in `GLCanvas3D::_render_assemble_control()` after `model_objects_clipper()` returned null.
- One dump faulted through `ObjectList::OnEditingDone()` -> `Plater::set_current_canvas_as_dirty()` while the application was closing.

# Screenshots/Recordings/Graphs

Not applicable: these are lifetime and embedded-WebView crash fixes with no intended visual change.

## Tests

- `git diff --check origin/main...HEAD`
- `./build_linux.sh -sir -j 6`
  - Full release build completed (`646/646`).
  - `OrcaSlicer_profile_validator` built successfully.
  - AppImage dependency audit passed.
- Generated `OrcaSlicerWaveOverhangs_Linux_V2.4.0-dev.AppImage` successfully.
  - SHA-256: `b6dd59cea78081ca1444818fd00850e3adfcc9024f27679d62139cbbac175981`
- Launched the packaged AppImage on KDE Plasma/Wayland, restored the existing project, and closed it through the normal window-close path.
- Confirmed the smoke test produced no new core dump.

No focused unit test currently covers wxGTK teardown event ordering or the embedded WebKit document lifecycle.
